### PR TITLE
parser: lift regexp.MustCompile out of function scope

### DIFF
--- a/pkg/parsers/urlparser.go
+++ b/pkg/parsers/urlparser.go
@@ -61,6 +61,8 @@ type MediaFilters struct {
 	Protocol         Protocol          `json:"protocol"`
 }
 
+var urlParseRegexp = regexp.MustCompile(`(.*)\((.*)\)`)
+
 // URLParse will generate a MediaFilters struct with
 // all the filters that needs to be applied to the
 // master manifest. It will also return the master manifest
@@ -68,7 +70,7 @@ type MediaFilters struct {
 func URLParse(urlpath string) (string, *MediaFilters, error) {
 	mf := new(MediaFilters)
 	parts := strings.Split(urlpath, "/")
-	re := regexp.MustCompile(`(.*)\((.*)\)`)
+	re := urlParseRegexp
 	masterManifestPath := "/"
 
 	if strings.Contains(urlpath, ".m3u8") {


### PR DESCRIPTION
Performance of regexp.Compilation can slow down the parsing
function significantly when it is repeatedly called in a function, fix
this by putting it in the package scope so its only called once.