### PR TITLE
filter: allow filtering by stream type

### DIFF
--- a/pkg/filters/dash.go
+++ b/pkg/filters/dash.go
@@ -58,7 +58,7 @@ func (d *DASHFilter) FilterManifest(filters *parsers.MediaFilters) (string, erro
 		manifest.BaseURL = baseURLWithPath(path.Join(path.Dir(u.Path), manifest.BaseURL))
 	}
 
-	if filters.FilterStreamTypes != nil {
+	if filters.FilterStreamTypes != nil && len(filters.FilterStreamTypes) > 0 {
 		d.filterAdaptationSetType(filters, manifest)
 	}
 

--- a/pkg/filters/dash.go
+++ b/pkg/filters/dash.go
@@ -65,10 +65,10 @@ func (d *DASHFilter) FilterManifest(filters *parsers.MediaFilters) (string, erro
 }
 
 func (d *DASHFilter) filterCaptionTypes(filters *parsers.MediaFilters, manifest *mpd.MPD) {
-	supportedTypes := map[parsers.CaptionType]bool{}
+	supportedTypes := map[parsers.CaptionType]struct{}{}
 
 	for _, captionType := range filters.CaptionTypes {
-		supportedTypes[captionType] = true
+		supportedTypes[captionType] = struct{}{}
 	}
 
 	for _, period := range manifest.Periods {

--- a/pkg/filters/dash.go
+++ b/pkg/filters/dash.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"path"
+	"strconv"
 	"strings"
 
 	"github.com/cbsinteractive/bakery/pkg/config"
@@ -57,6 +58,10 @@ func (d *DASHFilter) FilterManifest(filters *parsers.MediaFilters) (string, erro
 		manifest.BaseURL = baseURLWithPath(path.Join(path.Dir(u.Path), manifest.BaseURL))
 	}
 
+	if filters.FilterStreamTypes != nil {
+		d.filterAdaptationSetType(filters, manifest)
+	}
+
 	if filters.CaptionTypes != nil {
 		d.filterCaptionTypes(filters, manifest)
 	}
@@ -65,10 +70,9 @@ func (d *DASHFilter) FilterManifest(filters *parsers.MediaFilters) (string, erro
 }
 
 func (d *DASHFilter) filterCaptionTypes(filters *parsers.MediaFilters, manifest *mpd.MPD) {
-	supportedTypes := map[parsers.CaptionType]struct{}{}
-
+	supportedCaptionTypes := map[parsers.CaptionType]struct{}{}
 	for _, captionType := range filters.CaptionTypes {
-		supportedTypes[captionType] = struct{}{}
+		supportedCaptionTypes[captionType] = struct{}{}
 	}
 
 	for _, period := range manifest.Periods {
@@ -86,7 +90,7 @@ func (d *DASHFilter) filterCaptionTypes(filters *parsers.MediaFilters, manifest 
 						continue
 					}
 
-					if _, supported := supportedTypes[parsers.CaptionType(*r.Codecs)]; supported {
+					if _, supported := supportedCaptionTypes[parsers.CaptionType(*r.Codecs)]; supported {
 						filteredReps = append(filteredReps, r)
 					}
 				}
@@ -95,4 +99,46 @@ func (d *DASHFilter) filterCaptionTypes(filters *parsers.MediaFilters, manifest 
 			}
 		}
 	}
+}
+
+func (d *DASHFilter) filterAdaptationSetType(filters *parsers.MediaFilters, manifest *mpd.MPD) {
+	filteredAdaptationSetTypes := map[parsers.StreamType]struct{}{}
+	for _, streamType := range filters.FilterStreamTypes {
+		filteredAdaptationSetTypes[streamType] = struct{}{}
+	}
+
+	periodIndex := 0
+	var filteredPeriods []*mpd.Period
+	for _, period := range manifest.Periods {
+		var filteredAdaptationSets []*mpd.AdaptationSet
+		asIndex := 0
+		for _, as := range period.AdaptationSets {
+			if as.ContentType != nil {
+				if _, filtered := filteredAdaptationSetTypes[parsers.StreamType(*as.ContentType)]; filtered {
+					continue
+				}
+			}
+
+			as.ID = strptr(strconv.Itoa(asIndex))
+			asIndex++
+
+			filteredAdaptationSets = append(filteredAdaptationSets, as)
+		}
+
+		if len(filteredAdaptationSets) == 0 {
+			continue
+		}
+
+		period.AdaptationSets = filteredAdaptationSets
+		period.ID = strconv.Itoa(periodIndex)
+		periodIndex++
+
+		filteredPeriods = append(filteredPeriods, period)
+	}
+
+	manifest.Periods = filteredPeriods
+}
+
+func strptr(s string) *string {
+	return &s
 }

--- a/pkg/parsers/urlparser.go
+++ b/pkg/parsers/urlparser.go
@@ -23,6 +23,9 @@ type CaptionLanguage string
 // CaptionType is an allowed caption format for the stream
 type CaptionType string
 
+// StreamType represents one stream type (e.g. video, audio, text)
+type StreamType string
+
 // Protocol describe the valid protocols
 type Protocol string
 
@@ -51,14 +54,15 @@ const (
 
 // MediaFilters is a struct that carry all the information passed via url
 type MediaFilters struct {
-	Videos           []VideoType       `json:"Videos,omitempty"`
-	Audios           []AudioType       `json:"Audios,omitempty"`
-	AudioLanguages   []AudioLanguage   `json:"AudioLanguages,omitempty"`
-	CaptionLanguages []CaptionLanguage `json:"CaptionLanguages,omitempty"`
-	CaptionTypes     []CaptionType     `json:"CaptionTypes,omitempty"`
-	MaxBitrate       int               `json:"MinBitrate,omitempty"`
-	MinBitrate       int               `json:"MaxBitrate,omitempty"`
-	Protocol         Protocol          `json:"protocol"`
+	Videos            []VideoType       `json:",omitempty"`
+	Audios            []AudioType       `json:",omitempty"`
+	AudioLanguages    []AudioLanguage   `json:",omitempty"`
+	CaptionLanguages  []CaptionLanguage `json:",omitempty"`
+	CaptionTypes      []CaptionType     `json:",omitempty"`
+	FilterStreamTypes []StreamType      `json:",omitempty"`
+	MaxBitrate        int               `json:",omitempty"`
+	MinBitrate        int               `json:",omitempty"`
+	Protocol          Protocol          `json:"protocol"`
 }
 
 var urlParseRegexp = regexp.MustCompile(`(.*)\((.*)\)`)
@@ -120,6 +124,10 @@ func URLParse(urlpath string) (string, *MediaFilters, error) {
 
 			for _, captionType := range filters {
 				mf.CaptionTypes = append(mf.CaptionTypes, CaptionType(captionType))
+			}
+		case "fs":
+			for _, streamType := range filters {
+				mf.FilterStreamTypes = append(mf.FilterStreamTypes, StreamType(streamType))
 			}
 		case "b":
 			if filters[0] != "" {


### PR DESCRIPTION
Added a new filter `fs` for "filter stream type". A request missing
this filter or passing this filter without values does not modify the 
manifest. Passing this filter as `fs(text)` will remove text adaptation
sets from your DASH manifests. The filter will take care of removing
empty periods and re-writing `Period` and `AdaptationSet` element
IDs if content is removed.