### PR TITLE
Refactor filters; Add HDR.

### DIFF
--- a/pkg/filters/dash.go
+++ b/pkg/filters/dash.go
@@ -130,9 +130,11 @@ func filterContentType(filter ContentType, supportedContentTypes map[string]stru
 						continue
 					}
 
-					if isCodecSupported(*r.Codecs, filter, supportedContentTypes) {
-						filteredReps = append(filteredReps, r)
+					if matchCodec(*r.Codecs, filter, supportedContentTypes) {
+						continue
 					}
+
+					filteredReps = append(filteredReps, r)
 				}
 				as.Representations = filteredReps
 			}
@@ -187,7 +189,7 @@ func (d *DASHFilter) filterAdaptationSetType(filters *parsers.MediaFilters, mani
 	manifest.Periods = filteredPeriods
 }
 
-func isCodecSupported(codec string, ct ContentType, supportedCodecs map[string]struct{}) bool {
+func matchCodec(codec string, ct ContentType, supportedCodecs map[string]struct{}) bool {
 	//the key in supportedCodecs for captionContentType is equivalent to codec
 	//advertised in manifest. we can avoid iterating through each key
 	if ct == captionContentType {

--- a/pkg/filters/dash_test.go
+++ b/pkg/filters/dash_test.go
@@ -91,6 +91,12 @@ func TestDASHFilter_FilterManifest_videoCodecs(t *testing.T) {
       <Representation bandwidth="256" codecs="hvc1.2.4.L90.90" id="1"></Representation>
       <Representation bandwidth="256" codecs="hvc1.2.4.L120.90" id="2"></Representation>
       <Representation bandwidth="256" codecs="hvc1.2.4.L63.90" id="3"></Representation>
+      <Representation bandwidth="256" codecs="hvc1.1.4.L120.90" id="4"></Representation>
+      <Representation bandwidth="256" codecs="hvc1.1.4.L63.90" id="5"></Representation>
+      <Representation bandwidth="256" codecs="hev1.1.4.L120.90" id="6"></Representation>
+      <Representation bandwidth="256" codecs="hev1.1.4.L63.90" id="7"></Representation>
+      <Representation bandwidth="256" codecs="hev1.2.4.L120.90" id="8"></Representation>
+      <Representation bandwidth="256" codecs="hev1.3.4.L63.90" id="9"></Representation>
     </AdaptationSet>
     <AdaptationSet id="1" lang="en" contentType="video">
       <Representation bandwidth="256" codecs="dvh1.05.01" id="0"></Representation>
@@ -118,6 +124,12 @@ func TestDASHFilter_FilterManifest_videoCodecs(t *testing.T) {
       <Representation bandwidth="256" codecs="hvc1.2.4.L90.90" id="1"></Representation>
       <Representation bandwidth="256" codecs="hvc1.2.4.L120.90" id="2"></Representation>
       <Representation bandwidth="256" codecs="hvc1.2.4.L63.90" id="3"></Representation>
+      <Representation bandwidth="256" codecs="hvc1.1.4.L120.90" id="4"></Representation>
+      <Representation bandwidth="256" codecs="hvc1.1.4.L63.90" id="5"></Representation>
+      <Representation bandwidth="256" codecs="hev1.1.4.L120.90" id="6"></Representation>
+      <Representation bandwidth="256" codecs="hev1.1.4.L63.90" id="7"></Representation>
+      <Representation bandwidth="256" codecs="hev1.2.4.L120.90" id="8"></Representation>
+      <Representation bandwidth="256" codecs="hev1.3.4.L63.90" id="9"></Representation>
     </AdaptationSet>
     <AdaptationSet id="1" lang="en" contentType="video">
       <Representation bandwidth="256" codecs="avc1.640028" id="0"></Representation>
@@ -159,6 +171,12 @@ func TestDASHFilter_FilterManifest_videoCodecs(t *testing.T) {
       <Representation bandwidth="256" codecs="hvc1.2.4.L90.90" id="1"></Representation>
       <Representation bandwidth="256" codecs="hvc1.2.4.L120.90" id="2"></Representation>
       <Representation bandwidth="256" codecs="hvc1.2.4.L63.90" id="3"></Representation>
+      <Representation bandwidth="256" codecs="hvc1.1.4.L120.90" id="4"></Representation>
+      <Representation bandwidth="256" codecs="hvc1.1.4.L63.90" id="5"></Representation>
+      <Representation bandwidth="256" codecs="hev1.1.4.L120.90" id="6"></Representation>
+      <Representation bandwidth="256" codecs="hev1.1.4.L63.90" id="7"></Representation>
+      <Representation bandwidth="256" codecs="hev1.2.4.L120.90" id="8"></Representation>
+      <Representation bandwidth="256" codecs="hev1.3.4.L63.90" id="9"></Representation>
     </AdaptationSet>
     <AdaptationSet id="1" lang="en" contentType="video">
       <Representation bandwidth="256" codecs="dvh1.05.01" id="0"></Representation>
@@ -195,6 +213,34 @@ func TestDASHFilter_FilterManifest_videoCodecs(t *testing.T) {
 </MPD>
 `
 
+	manifestWithoutHDR10 := `<?xml version="1.0" encoding="UTF-8"?>
+<MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" type="static" mediaPresentationDuration="PT6M16S" minBufferTime="PT1.97S">
+  <BaseURL>http://existing.base/url/</BaseURL>
+  <Period>
+    <AdaptationSet id="0" lang="en" contentType="video">
+      <Representation bandwidth="256" codecs="hvc1.1.4.L120.90" id="4"></Representation>
+      <Representation bandwidth="256" codecs="hvc1.1.4.L63.90" id="5"></Representation>
+      <Representation bandwidth="256" codecs="hev1.1.4.L120.90" id="6"></Representation>
+      <Representation bandwidth="256" codecs="hev1.1.4.L63.90" id="7"></Representation>
+      <Representation bandwidth="256" codecs="hev1.3.4.L63.90" id="9"></Representation>
+    </AdaptationSet>
+    <AdaptationSet id="1" lang="en" contentType="video">
+      <Representation bandwidth="256" codecs="dvh1.05.01" id="0"></Representation>
+      <Representation bandwidth="256" codecs="dvh1.05.03" id="1"></Representation>
+    </AdaptationSet>
+    <AdaptationSet id="2" lang="en" contentType="video">
+      <Representation bandwidth="256" codecs="avc1.640028" id="0"></Representation>
+    </AdaptationSet>
+    <AdaptationSet id="3" lang="en" contentType="audio">
+      <Representation bandwidth="256" codecs="mp4a.40.2" id="0"></Representation>
+    </AdaptationSet>
+    <AdaptationSet id="4" lang="en" contentType="text">
+      <Representation bandwidth="256" codecs="wvtt" id="0"></Representation>
+    </AdaptationSet>
+  </Period>
+</MPD>
+`
+
 	manifestWithoutVideo := `<?xml version="1.0" encoding="UTF-8"?>
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" type="static" mediaPresentationDuration="PT6M16S" minBufferTime="PT1.97S">
   <BaseURL>http://existing.base/url/</BaseURL>
@@ -218,13 +264,13 @@ func TestDASHFilter_FilterManifest_videoCodecs(t *testing.T) {
 	}{
 		{
 			name:                  "when all video codecs are supplied, all video is stripped from a manifest",
-			filters:               &parsers.MediaFilters{Videos: []parsers.VideoType{"hvc", "avc", "dvh"}},
+			filters:               &parsers.MediaFilters{Videos: []parsers.VideoType{"hvc", "hev", "avc", "dvh"}},
 			manifestContent:       manifestWithMultiVideoCodec,
 			expectManifestContent: manifestWithoutVideo,
 		},
 		{
 			name:                  "when a video filter is supplied with HEVC and AVC, HEVC and AVC is stripped from manifest",
-			filters:               &parsers.MediaFilters{Videos: []parsers.VideoType{"hvc", "avc"}},
+			filters:               &parsers.MediaFilters{Videos: []parsers.VideoType{"hvc", "hev", "avc"}},
 			manifestContent:       manifestWithMultiVideoCodec,
 			expectManifestContent: manifestWithoutHEVCAndAVCVideoCodec,
 		},
@@ -236,7 +282,7 @@ func TestDASHFilter_FilterManifest_videoCodecs(t *testing.T) {
 		},
 		{
 			name:                  "when a video filter is suplied with HEVC ID, HEVC is stripped from manifest",
-			filters:               &parsers.MediaFilters{Videos: []parsers.VideoType{"hvc"}},
+			filters:               &parsers.MediaFilters{Videos: []parsers.VideoType{"hvc", "hev"}},
 			manifestContent:       manifestWithMultiVideoCodec,
 			expectManifestContent: manifestWithoutHEVCVideoCodec,
 		},
@@ -245,6 +291,12 @@ func TestDASHFilter_FilterManifest_videoCodecs(t *testing.T) {
 			filters:               &parsers.MediaFilters{Videos: []parsers.VideoType{"avc"}},
 			manifestContent:       manifestWithMultiVideoCodec,
 			expectManifestContent: manifestWithoutAVCVideoCodec,
+		},
+		{
+			name:                  "when a video filter is suplied with HDR10, all hevc main10 profiles are stripped from manifest",
+			filters:               &parsers.MediaFilters{Videos: []parsers.VideoType{"hvc1.2", "hev1.2"}},
+			manifestContent:       manifestWithMultiVideoCodec,
+			expectManifestContent: manifestWithoutHDR10,
 		},
 		{
 			name:                  "when no video filters are supplied, nothing is stripped from manifest",

--- a/pkg/filters/dash_test.go
+++ b/pkg/filters/dash_test.go
@@ -109,7 +109,7 @@ func TestDASHFilter_FilterManifest_videoCodecs(t *testing.T) {
 </MPD>
 `
 
-	manifestWithHEVCAndAVCVideoCodec := `<?xml version="1.0" encoding="UTF-8"?>
+	manifestWithoutDolbyVisionCodec := `<?xml version="1.0" encoding="UTF-8"?>
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" type="static" mediaPresentationDuration="PT6M16S" minBufferTime="PT1.97S">
   <BaseURL>http://existing.base/url/</BaseURL>
   <Period>
@@ -132,7 +132,7 @@ func TestDASHFilter_FilterManifest_videoCodecs(t *testing.T) {
 </MPD>
 `
 
-	manifestWithDolbyVideoVisionCodec := `<?xml version="1.0" encoding="UTF-8"?>
+	manifestWithoutHEVCAndAVCVideoCodec := `<?xml version="1.0" encoding="UTF-8"?>
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" type="static" mediaPresentationDuration="PT6M16S" minBufferTime="PT1.97S">
   <BaseURL>http://existing.base/url/</BaseURL>
   <Period>
@@ -150,7 +150,7 @@ func TestDASHFilter_FilterManifest_videoCodecs(t *testing.T) {
 </MPD>
 `
 
-	manifestWithHEVCVideoCodec := `<?xml version="1.0" encoding="UTF-8"?>
+	manifestWithoutAVCVideoCodec := `<?xml version="1.0" encoding="UTF-8"?>
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" type="static" mediaPresentationDuration="PT6M16S" minBufferTime="PT1.97S">
   <BaseURL>http://existing.base/url/</BaseURL>
   <Period>
@@ -160,27 +160,35 @@ func TestDASHFilter_FilterManifest_videoCodecs(t *testing.T) {
       <Representation bandwidth="256" codecs="hvc1.2.4.L120.90" id="2"></Representation>
       <Representation bandwidth="256" codecs="hvc1.2.4.L63.90" id="3"></Representation>
     </AdaptationSet>
-    <AdaptationSet id="1" lang="en" contentType="audio">
+    <AdaptationSet id="1" lang="en" contentType="video">
+      <Representation bandwidth="256" codecs="dvh1.05.01" id="0"></Representation>
+      <Representation bandwidth="256" codecs="dvh1.05.03" id="1"></Representation>
+    </AdaptationSet>
+    <AdaptationSet id="2" lang="en" contentType="audio">
       <Representation bandwidth="256" codecs="mp4a.40.2" id="0"></Representation>
     </AdaptationSet>
-    <AdaptationSet id="2" lang="en" contentType="text">
+    <AdaptationSet id="3" lang="en" contentType="text">
       <Representation bandwidth="256" codecs="wvtt" id="0"></Representation>
     </AdaptationSet>
   </Period>
 </MPD>
 `
 
-	manifestWithAVCVideoCodec := `<?xml version="1.0" encoding="UTF-8"?>
+	manifestWithoutHEVCVideoCodec := `<?xml version="1.0" encoding="UTF-8"?>
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" type="static" mediaPresentationDuration="PT6M16S" minBufferTime="PT1.97S">
   <BaseURL>http://existing.base/url/</BaseURL>
   <Period>
     <AdaptationSet id="0" lang="en" contentType="video">
+      <Representation bandwidth="256" codecs="dvh1.05.01" id="0"></Representation>
+      <Representation bandwidth="256" codecs="dvh1.05.03" id="1"></Representation>
+    </AdaptationSet>
+    <AdaptationSet id="1" lang="en" contentType="video">
       <Representation bandwidth="256" codecs="avc1.640028" id="0"></Representation>
     </AdaptationSet>
-    <AdaptationSet id="1" lang="en" contentType="audio">
+    <AdaptationSet id="2" lang="en" contentType="audio">
       <Representation bandwidth="256" codecs="mp4a.40.2" id="0"></Representation>
     </AdaptationSet>
-    <AdaptationSet id="2" lang="en" contentType="text">
+    <AdaptationSet id="3" lang="en" contentType="text">
       <Representation bandwidth="256" codecs="wvtt" id="0"></Representation>
     </AdaptationSet>
   </Period>
@@ -209,34 +217,34 @@ func TestDASHFilter_FilterManifest_videoCodecs(t *testing.T) {
 		expectErr             bool
 	}{
 		{
-			name:                  "when an empty video filter list is supplied, video is stripped from a manifest",
-			filters:               &parsers.MediaFilters{Videos: []parsers.VideoType{}},
+			name:                  "when all video codecs are supplied, all video is stripped from a manifest",
+			filters:               &parsers.MediaFilters{Videos: []parsers.VideoType{"hvc", "avc", "dvh"}},
 			manifestContent:       manifestWithMultiVideoCodec,
 			expectManifestContent: manifestWithoutVideo,
 		},
 		{
-			name:                  "when a video filter is supplied with HEVC and AVC, all video except for HEVC and AVC is stripped",
+			name:                  "when a video filter is supplied with HEVC and AVC, HEVC and AVC is stripped from manifest",
 			filters:               &parsers.MediaFilters{Videos: []parsers.VideoType{"hvc", "avc"}},
 			manifestContent:       manifestWithMultiVideoCodec,
-			expectManifestContent: manifestWithHEVCAndAVCVideoCodec,
+			expectManifestContent: manifestWithoutHEVCAndAVCVideoCodec,
 		},
 		{
-			name:                  "when a video filter is suplied with Dolby Vision ID, all video except for dolby vision is stripped",
+			name:                  "when a video filter is suplied with Dolby Vision ID, dolby vision is stripped from manifest",
 			filters:               &parsers.MediaFilters{Videos: []parsers.VideoType{"dvh"}},
 			manifestContent:       manifestWithMultiVideoCodec,
-			expectManifestContent: manifestWithDolbyVideoVisionCodec,
+			expectManifestContent: manifestWithoutDolbyVisionCodec,
 		},
 		{
-			name:                  "when a video filter is suplied with HEVC ID, all video except for HEVC is stripped",
+			name:                  "when a video filter is suplied with HEVC ID, HEVC is stripped from manifest",
 			filters:               &parsers.MediaFilters{Videos: []parsers.VideoType{"hvc"}},
 			manifestContent:       manifestWithMultiVideoCodec,
-			expectManifestContent: manifestWithHEVCVideoCodec,
+			expectManifestContent: manifestWithoutHEVCVideoCodec,
 		},
 		{
-			name:                  "when a video filter is suplied with AVC, all video except for AVC is stripped",
+			name:                  "when a video filter is suplied with AVC, AVC is stripped from manifest",
 			filters:               &parsers.MediaFilters{Videos: []parsers.VideoType{"avc"}},
 			manifestContent:       manifestWithMultiVideoCodec,
-			expectManifestContent: manifestWithAVCVideoCodec,
+			expectManifestContent: manifestWithoutAVCVideoCodec,
 		},
 		{
 			name:                  "when no video filters are supplied, nothing is stripped from manifest",
@@ -284,7 +292,7 @@ func TestDASHFilter_FilterManifest_audioCodecs(t *testing.T) {
 </MPD>
 `
 
-	manifestWithEAC3AudioCodec := `<?xml version="1.0" encoding="UTF-8"?>
+	manifestWithoutAC3AudioCodec := `<?xml version="1.0" encoding="UTF-8"?>
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" type="static" mediaPresentationDuration="PT6M16S" minBufferTime="PT1.97S">
   <BaseURL>http://existing.base/url/</BaseURL>
   <Period>
@@ -298,7 +306,7 @@ func TestDASHFilter_FilterManifest_audioCodecs(t *testing.T) {
 </MPD>
 `
 
-	manifestWithAC3AudioCodec := `<?xml version="1.0" encoding="UTF-8"?>
+	manifestWithoutEAC3AudioCodec := `<?xml version="1.0" encoding="UTF-8"?>
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" type="static" mediaPresentationDuration="PT6M16S" minBufferTime="PT1.97S">
   <BaseURL>http://existing.base/url/</BaseURL>
   <Period>
@@ -331,22 +339,22 @@ func TestDASHFilter_FilterManifest_audioCodecs(t *testing.T) {
 		expectErr             bool
 	}{
 		{
-			name:                  "when an empty audio filter list is supplied, audio is stripped from a manifest",
-			filters:               &parsers.MediaFilters{Audios: []parsers.AudioType{}},
+			name:                  "when all codecs are applied, audio is stripped from a manifest",
+			filters:               &parsers.MediaFilters{Audios: []parsers.AudioType{"ac-3", "ec-3"}},
 			manifestContent:       manifestWithEAC3AndAC3AudioCodec,
 			expectManifestContent: manifestWithoutAudio,
 		},
 		{
-			name:                  "when an audio filter is supplied with Enhanced AC-3 codec, AC-3 is stripped out",
+			name:                  "when an audio filter is supplied with Enhanced AC-3 codec, Enhanced AC-3 is stripped out",
 			filters:               &parsers.MediaFilters{Audios: []parsers.AudioType{"ec-3"}},
 			manifestContent:       manifestWithEAC3AndAC3AudioCodec,
-			expectManifestContent: manifestWithEAC3AudioCodec,
+			expectManifestContent: manifestWithoutEAC3AudioCodec,
 		},
 		{
-			name:                  "when an audio filter is supplied with AC-3 codec, Enhanced AC-3 is stripped out",
+			name:                  "when an audio filter is supplied with AC-3 codec, AC-3 is stripped out",
 			filters:               &parsers.MediaFilters{Audios: []parsers.AudioType{"ac-3"}},
 			manifestContent:       manifestWithEAC3AndAC3AudioCodec,
-			expectManifestContent: manifestWithAC3AudioCodec,
+			expectManifestContent: manifestWithoutAC3AudioCodec,
 		},
 		{
 			name:                  "when no audio filters are supplied, nothing is stripped from manifest",
@@ -391,7 +399,7 @@ func TestDASHFilter_FilterManifest_captionTypes(t *testing.T) {
 </MPD>
 `
 
-	manifestWithWVTTCaptions := `<?xml version="1.0" encoding="UTF-8"?>
+	manifestWithoutSTPPCaptions := `<?xml version="1.0" encoding="UTF-8"?>
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" type="static" mediaPresentationDuration="PT6M16S" minBufferTime="PT1.97S">
   <BaseURL>http://existing.base/url/</BaseURL>
   <Period>
@@ -402,7 +410,7 @@ func TestDASHFilter_FilterManifest_captionTypes(t *testing.T) {
 </MPD>
 `
 
-	manifestWithSTPPCaptions := `<?xml version="1.0" encoding="UTF-8"?>
+	manifestWithoutWVTTCaptions := `<?xml version="1.0" encoding="UTF-8"?>
 <MPD xmlns="urn:mpeg:dash:schema:mpd:2011" profiles="urn:mpeg:dash:profile:isoff-on-demand:2011" type="static" mediaPresentationDuration="PT6M16S" minBufferTime="PT1.97S">
   <BaseURL>http://existing.base/url/</BaseURL>
   <Period>
@@ -428,9 +436,9 @@ func TestDASHFilter_FilterManifest_captionTypes(t *testing.T) {
 		expectErr             bool
 	}{
 		{
-			name: "when an empty caption type filter list is supplied, captions are stripped from a " +
+			name: "when all caption types are supplied, captions are stripped from a " +
 				"manifest",
-			filters:               &parsers.MediaFilters{CaptionTypes: []parsers.CaptionType{}},
+			filters:               &parsers.MediaFilters{CaptionTypes: []parsers.CaptionType{"stpp", "wvtt"}},
 			manifestContent:       manifestWithWVTTAndSTPPCaptions,
 			expectManifestContent: manifestWithoutCaptions,
 		},
@@ -439,14 +447,14 @@ func TestDASHFilter_FilterManifest_captionTypes(t *testing.T) {
 				"filtered out",
 			filters:               &parsers.MediaFilters{CaptionTypes: []parsers.CaptionType{"stpp"}},
 			manifestContent:       manifestWithWVTTAndSTPPCaptions,
-			expectManifestContent: manifestWithSTPPCaptions,
+			expectManifestContent: manifestWithoutSTPPCaptions,
 		},
 		{
 			name: "when a caption type filter is supplied with wvtt only, stpp captions are " +
 				"filtered out",
 			filters:               &parsers.MediaFilters{CaptionTypes: []parsers.CaptionType{"wvtt"}},
 			manifestContent:       manifestWithWVTTAndSTPPCaptions,
-			expectManifestContent: manifestWithWVTTCaptions,
+			expectManifestContent: manifestWithoutWVTTCaptions,
 		},
 		{
 			name:                  "when no filters are supplied, captions are not stripped from a manifest",

--- a/pkg/filters/hls_test.go
+++ b/pkg/filters/hls_test.go
@@ -172,7 +172,7 @@ http://existing.base/uri/link_7.m3u8
 http://existing.base/uri/link_8.m3u8
 `
 
-	manifestFilterInEC3AndAC3 := `#EXTM3U
+	manifestFilterWithoutMP4A := `#EXTM3U
 #EXT-X-VERSION:3
 #EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=1000,AVERAGE-BANDWIDTH=1000,CODECS="ec-3"
 http://existing.base/uri/link_1.m3u8
@@ -190,7 +190,7 @@ http://existing.base/uri/link_7.m3u8
 http://existing.base/uri/link_8.m3u8
 `
 
-	manifestFilterInEC3AndMP4A := `#EXTM3U
+	manifestFilterWithoutAC3 := `#EXTM3U
 #EXT-X-VERSION:3
 #EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=1000,AVERAGE-BANDWIDTH=1000,CODECS="ec-3"
 http://existing.base/uri/link_1.m3u8
@@ -224,40 +224,40 @@ http://existing.base/uri/link_8.m3u8
 		expectErr             bool
 	}{
 		{
-			name:                  "when given empty audio filter list, expect variants with ac-3, ec-3 and/or mp4a to be stripped out",
-			filters:               &parsers.MediaFilters{Audios: []parsers.AudioType{}},
+			name:                  "when all audio codecs are supplies, expect audio to be stripped out",
+			filters:               &parsers.MediaFilters{Audios: []parsers.AudioType{"mp4a", "ec-3", "ac-3"}},
 			manifestContent:       manifestWithAllAudio,
 			expectManifestContent: manifestWithoutAudio,
 		},
 		{
-			name:                  "when filtering in ec-3, expect variants with ac-3 and/or mp4a to be stripped out",
-			filters:               &parsers.MediaFilters{Audios: []parsers.AudioType{"ec-3"}},
+			name:                  "when filtering in ac-3 and mp4a, expect variants with ac-3 and/or mp4a to be stripped out",
+			filters:               &parsers.MediaFilters{Audios: []parsers.AudioType{"ac-3", "mp4a"}},
 			manifestContent:       manifestWithAllAudio,
 			expectManifestContent: manifestFilterInEC3,
 		},
 		{
-			name:                  "when filtering in ac-3, expect variants with ec-3 and/or mp4a to be stripped out",
+			name:                  "when filtering in ac-3, expect variants with ac-3 to be stripped out",
 			filters:               &parsers.MediaFilters{Audios: []parsers.AudioType{"ac-3"}},
 			manifestContent:       manifestWithAllAudio,
-			expectManifestContent: manifestFilterInAC3,
+			expectManifestContent: manifestFilterWithoutAC3,
 		},
 		{
-			name:                  "when filtering in mp4a, expect variants with ec-3 and/or ac-3 to be stripped out",
+			name:                  "when filtering in mp4a, expect variants with mp4a to be stripped out",
 			filters:               &parsers.MediaFilters{Audios: []parsers.AudioType{"mp4a"}},
+			manifestContent:       manifestWithAllAudio,
+			expectManifestContent: manifestFilterWithoutMP4A,
+		},
+		{
+			name:                  "when filtering in ec-3 and ac-3, expect variants with ec-3 and ac-3 to be stripped out",
+			filters:               &parsers.MediaFilters{Audios: []parsers.AudioType{"ec-3", "ac-3"}},
 			manifestContent:       manifestWithAllAudio,
 			expectManifestContent: manifestFilterInMP4A,
 		},
 		{
-			name:                  "when filtering in ec-3 and ac-3, expect variants with mp4a to be stripped out",
-			filters:               &parsers.MediaFilters{Audios: []parsers.AudioType{"ec-3", "ac-3"}},
-			manifestContent:       manifestWithAllAudio,
-			expectManifestContent: manifestFilterInEC3AndAC3,
-		},
-		{
-			name:                  "when filtering in ec-3 and mp4a, expect variants with ac-3 to be stripped out",
+			name:                  "when filtering in ec-3 and mp4a, expect variants with ec-3 and/or mp4a to be stripped out",
 			filters:               &parsers.MediaFilters{Audios: []parsers.AudioType{"ec-3", "mp4a"}},
 			manifestContent:       manifestWithAllAudio,
-			expectManifestContent: manifestFilterInEC3AndMP4A,
+			expectManifestContent: manifestFilterInAC3,
 		},
 		{
 			name:                  "when no audio filters are given, expect unfiltered manifest",
@@ -315,14 +315,12 @@ http://existing.base/uri/link_8.m3u8
 http://existing.base/uri/link_9.m3u8
 `
 
-	manifestFilterInAVC := `#EXTM3U
+	manifestFilterWithoutAVC := `#EXTM3U
 #EXT-X-VERSION:3
-#EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=1000,AVERAGE-BANDWIDTH=1000,CODECS="avc1.640020"
-http://existing.base/uri/link_1.m3u8
-#EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=1100,AVERAGE-BANDWIDTH=1100,CODECS="avc1.77.30"
-http://existing.base/uri/link_2.m3u8
-#EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=6000,AVERAGE-BANDWIDTH=6000,CODECS="avc1.77.30,ec-3"
-http://existing.base/uri/link_6.m3u8
+#EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=4000,AVERAGE-BANDWIDTH=4000,CODECS="hvc1.2.4.L93.90"
+http://existing.base/uri/link_3.m3u8
+#EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=4500,AVERAGE-BANDWIDTH=4500,CODECS="dvh1.05.01"
+http://existing.base/uri/link_4.m3u8
 #EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=1500,AVERAGE-BANDWIDTH=1500,CODECS="ec-3"
 http://existing.base/uri/link_7.m3u8
 #EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=1300,AVERAGE-BANDWIDTH=1300,CODECS="wvtt"
@@ -331,7 +329,7 @@ http://existing.base/uri/link_8.m3u8
 http://existing.base/uri/link_9.m3u8
 `
 
-	manifestFilterInHEVC := `#EXTM3U
+	manifestFilterWithoutAVCAndDVH := `#EXTM3U
 #EXT-X-VERSION:3
 #EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=4000,AVERAGE-BANDWIDTH=4000,CODECS="hvc1.2.4.L93.90"
 http://existing.base/uri/link_3.m3u8
@@ -343,7 +341,7 @@ http://existing.base/uri/link_8.m3u8
 http://existing.base/uri/link_9.m3u8
 `
 
-	manifestFilterInDVH := `#EXTM3U
+	manifestFilterWithoutAVCAndHEVC := `#EXTM3U
 #EXT-X-VERSION:3
 #EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=4500,AVERAGE-BANDWIDTH=4500,CODECS="dvh1.05.01"
 http://existing.base/uri/link_4.m3u8
@@ -355,7 +353,7 @@ http://existing.base/uri/link_8.m3u8
 http://existing.base/uri/link_9.m3u8
 `
 
-	manifestFilterInAVCAndHEVC := `#EXTM3U
+	manifestFilterWithoutDVH := `#EXTM3U
 #EXT-X-VERSION:3
 #EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=1000,AVERAGE-BANDWIDTH=1000,CODECS="avc1.640020"
 http://existing.base/uri/link_1.m3u8
@@ -375,7 +373,7 @@ http://existing.base/uri/link_8.m3u8
 http://existing.base/uri/link_9.m3u8
 `
 
-	manifestFilterInAVCAndDVH := `#EXTM3U
+	manifestFilterWithoutHEVC := `#EXTM3U
 #EXT-X-VERSION:3
 #EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=1000,AVERAGE-BANDWIDTH=1000,CODECS="avc1.640020"
 http://existing.base/uri/link_1.m3u8
@@ -411,40 +409,40 @@ http://existing.base/uri/link_9.m3u8
 		expectErr             bool
 	}{
 		{
-			name:                  "when given empty video filter list, expect variants with avc, hevc, and/or dvh to be stripped out",
-			filters:               &parsers.MediaFilters{Videos: []parsers.VideoType{}},
+			name:                  "when all video codecs are supllied, expect variants with avc, hevc, and/or dvh to be stripped out",
+			filters:               &parsers.MediaFilters{Videos: []parsers.VideoType{"avc", "hvc", "dvh"}},
 			manifestContent:       manifestWithAllVideo,
 			expectManifestContent: manifestWithoutVideo,
 		},
 		{
-			name:                  "when filtering in avc, expect variants with hevc and/or dvh to be stripped out",
+			name:                  "when filtering in avc, expect variants with avc to be stripped out",
 			filters:               &parsers.MediaFilters{Videos: []parsers.VideoType{"avc"}},
 			manifestContent:       manifestWithAllVideo,
-			expectManifestContent: manifestFilterInAVC,
+			expectManifestContent: manifestFilterWithoutAVC,
 		},
 		{
-			name:                  "when filtering in hevc, expect variants with avc and/or hevc to be stripped out",
+			name:                  "when filtering in hevc, expect hevc to be stripped out",
 			filters:               &parsers.MediaFilters{Videos: []parsers.VideoType{"hvc"}},
 			manifestContent:       manifestWithAllVideo,
-			expectManifestContent: manifestFilterInHEVC,
+			expectManifestContent: manifestFilterWithoutHEVC,
 		},
 		{
-			name:                  "when filtering in dvh, expect variants with avc and/or hevc to be stripped out",
+			name:                  "when filtering in dvh, expect dvh to be stripped out",
 			filters:               &parsers.MediaFilters{Videos: []parsers.VideoType{"dvh"}},
 			manifestContent:       manifestWithAllVideo,
-			expectManifestContent: manifestFilterInDVH,
+			expectManifestContent: manifestFilterWithoutDVH,
 		},
 		{
-			name:                  "when filtering in avc and hevc, expect variants with dvh to be stripped out",
+			name:                  "when filtering in avc and hevc, expect variants with avc and hevc to be stripped out",
 			filters:               &parsers.MediaFilters{Videos: []parsers.VideoType{"avc", "hvc"}},
 			manifestContent:       manifestWithAllVideo,
-			expectManifestContent: manifestFilterInAVCAndHEVC,
+			expectManifestContent: manifestFilterWithoutAVCAndHEVC,
 		},
 		{
-			name:                  "when filtering in avc and dvh, expect variants with hevc to be stripped out",
+			name:                  "when filtering in avc and dvh, expect variants with avc and dvh to be stripped out",
 			filters:               &parsers.MediaFilters{Videos: []parsers.VideoType{"avc", "dvh"}},
 			manifestContent:       manifestWithAllVideo,
-			expectManifestContent: manifestFilterInAVCAndDVH,
+			expectManifestContent: manifestFilterWithoutAVCAndDVH,
 		},
 		{
 			name:                  "when no video filters are given, expect unfiltered manifest",
@@ -496,7 +494,7 @@ http://existing.base/uri/link_6.m3u8
 http://existing.base/uri/link_7.m3u8
 `
 
-	manifestFilterInWVTT := `#EXTM3U
+	manifestFilterWithoutSTPP := `#EXTM3U
 #EXT-X-VERSION:3
 #EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=1000,AVERAGE-BANDWIDTH=1000,CODECS="wvtt"
 http://existing.base/uri/link_1.m3u8
@@ -510,7 +508,7 @@ http://existing.base/uri/link_6.m3u8
 http://existing.base/uri/link_7.m3u8
 `
 
-	manifestFilterInSTPP := `#EXTM3U
+	manifestFilterWithoutWVTT := `#EXTM3U
 #EXT-X-VERSION:3
 #EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=1100,AVERAGE-BANDWIDTH=1100,CODECS="stpp"
 http://existing.base/uri/link_2.m3u8
@@ -540,22 +538,22 @@ http://existing.base/uri/link_7.m3u8
 		expectErr             bool
 	}{
 		{
-			name:                  "when given empty caption filter list, expect variants with captions to be stripped out",
-			filters:               &parsers.MediaFilters{CaptionTypes: []parsers.CaptionType{}},
+			name:                  "when all caption filters are supplied, expect all caption variants with captions to be stripped out",
+			filters:               &parsers.MediaFilters{CaptionTypes: []parsers.CaptionType{"stpp", "wvtt"}},
 			manifestContent:       manifestWithAllCaptions,
 			expectManifestContent: manifestWithNoCaptions,
 		},
 		{
-			name:                  "when filtering in wvtt, expect variants with stpp to be stripped out",
+			name:                  "when filtering in wvtt, expect variants with wvtt to be stripped out",
 			filters:               &parsers.MediaFilters{CaptionTypes: []parsers.CaptionType{"wvtt"}},
 			manifestContent:       manifestWithAllCaptions,
-			expectManifestContent: manifestFilterInWVTT,
+			expectManifestContent: manifestFilterWithoutWVTT,
 		},
 		{
 			name:                  "when filtering in stpp, expect variants with wvtt to be stripped out",
 			filters:               &parsers.MediaFilters{CaptionTypes: []parsers.CaptionType{"stpp"}},
 			manifestContent:       manifestWithAllCaptions,
-			expectManifestContent: manifestFilterInSTPP,
+			expectManifestContent: manifestFilterWithoutSTPP,
 		},
 		{
 			name:                  "when no caption filter is given, expect original manifest",
@@ -709,38 +707,38 @@ http://existing.base/uri/link_14.m3u8
 		expectErr             bool
 	}{
 		{
-			name:                  "when no filters are given, expect original manifest",
+			name:                  "when empty filters are given, expect original manifest",
 			filters:               &parsers.MediaFilters{},
 			manifestContent:       manifestWithAllCodecs,
 			expectManifestContent: manifestWithAllCodecs,
 		},
 		{
-			name:                  "when filtering in audio (ac-3) and video (avc), expect variants with ec-3, mp4a, hevc, and/or dvh to be stripped out",
-			filters:               &parsers.MediaFilters{Audios: []parsers.AudioType{"ac-3"}, Videos: []parsers.VideoType{"avc"}},
+			name:                  "when filtering out audio (ec-3 and mp4a) and video (hevc and dvh), expect variants with ec-3, mp4a, hevc, and/or dvh to be stripped out",
+			filters:               &parsers.MediaFilters{Audios: []parsers.AudioType{"ec-3", "mp4a"}, Videos: []parsers.VideoType{"hvc", "dvh"}},
 			manifestContent:       manifestWithAllCodecs,
 			expectManifestContent: manifestFilterInAC3AndAVC,
 		},
 		{
-			name:                  "when filtering in audio (ac-3, ec-3) and video (avc), expect variants with mp4a, hevc, and/or dvh to be stripped out",
-			filters:               &parsers.MediaFilters{Audios: []parsers.AudioType{"ac-3", "ec-3"}, Videos: []parsers.VideoType{"avc"}},
+			name:                  "when filtering out audio (mp4a) and video (hevc and dvh), expect variants with mp4a, hevc, and/or dvh to be stripped out",
+			filters:               &parsers.MediaFilters{Audios: []parsers.AudioType{"mp4a"}, Videos: []parsers.VideoType{"hvc", "dvh"}},
 			manifestContent:       manifestWithAllCodecs,
 			expectManifestContent: manifestFilterInAC3AndEC3AndAVC,
 		},
 		{
-			name:                  "when filtering in audio (ac-3) and captions (wvtt), expect variants with ec-3, mp4a, and/or stpp to be stripped out",
-			filters:               &parsers.MediaFilters{Audios: []parsers.AudioType{"ac-3"}, CaptionTypes: []parsers.CaptionType{"wvtt"}},
+			name:                  "when filtering out audio (ec-3 and mp4a) and captions (stpp), expect variants with ec-3, mp4a, and/or stpp to be stripped out",
+			filters:               &parsers.MediaFilters{Audios: []parsers.AudioType{"ec-3", "mp4a"}, CaptionTypes: []parsers.CaptionType{"stpp"}},
 			manifestContent:       manifestWithAllCodecs,
 			expectManifestContent: manifestFilterInAC3AndWVTT,
 		},
 		{
-			name:                  "when filtering in audio (ac-3), video (avc), and captions (wvtt), expect variants with ec-3, mp4a, hevc, dvh, and/or stpp to be stripped out",
-			filters:               &parsers.MediaFilters{Audios: []parsers.AudioType{"ac-3"}, Videos: []parsers.VideoType{"avc"}, CaptionTypes: []parsers.CaptionType{"wvtt"}},
+			name:                  "when filtering out audio (ec-3 and mp4a), video (hevc and dvh), and captions (stpp), expect variants with ec-3, mp4a, hevc, dvh, and/or stpp to be stripped out",
+			filters:               &parsers.MediaFilters{Audios: []parsers.AudioType{"ec-3", "mp4a"}, Videos: []parsers.VideoType{"hvc", "dvh"}, CaptionTypes: []parsers.CaptionType{"stpp"}},
 			manifestContent:       manifestWithAllCodecs,
 			expectManifestContent: manifestFilterInAC3AndAVCAndWVTT,
 		},
 		{
-			name:                  "when filtering out all audio and filtering in video (avc), expect variants with ac-3, ec-3, mp4a, hevc, and/or dvh to be stripped out",
-			filters:               &parsers.MediaFilters{Audios: []parsers.AudioType{}, Videos: []parsers.VideoType{"avc"}},
+			name:                  "when filtering out all codecs except avc video, expect variants with ac-3, ec-3, mp4a, hevc, and/or dvh to be stripped out",
+			filters:               &parsers.MediaFilters{Audios: []parsers.AudioType{"ac-3", "ec-3", "mp4a"}, Videos: []parsers.VideoType{"hvc", "dvh"}, CaptionTypes: []parsers.CaptionType{"wvtt", "stpp"}},
 			manifestContent:       manifestWithAllCodecs,
 			expectManifestContent: manifestNoAudioAndFilterInAVC,
 		},
@@ -863,32 +861,32 @@ http://existing.base/uri/link_13.m3u8
 			expectManifestContent: manifestWithAllCodecsAndBandwidths,
 		},
 		{
-			name:                  "when filtering in audio (ac-3) in bandwidth range 4000-6000, expect variants with ec-3, mp4a, and/or not in range to be stripped out",
-			filters:               &parsers.MediaFilters{Audios: []parsers.AudioType{"ac-3"}, MinBitrate: 4000, MaxBitrate: 6000},
+			name:                  "when filtering out audio (ec-3) in bandwidth range 4000-6000, expect variants with ec-3, mp4a, and/or not in range to be stripped out",
+			filters:               &parsers.MediaFilters{Audios: []parsers.AudioType{"ec-3"}, MinBitrate: 4000, MaxBitrate: 6000},
 			manifestContent:       manifestWithAllCodecsAndBandwidths,
 			expectManifestContent: manifestFilter4000To6000BandwidthAndAC3,
 		},
 		{
-			name:                  "when filtering in video (dvh) in bandwidth range 4000-6000, expect variants with avc, hevc, and/or not in range to be stripped out",
-			filters:               &parsers.MediaFilters{Videos: []parsers.VideoType{"dvh"}, MinBitrate: 4000, MaxBitrate: 6000},
+			name:                  "when filtering out video (avc and hevc) in bandwidth range 4000-6000, expect variants with avc, hevc, and/or not in range to be stripped out",
+			filters:               &parsers.MediaFilters{Videos: []parsers.VideoType{"avc", "hvc"}, MinBitrate: 4000, MaxBitrate: 6000},
 			manifestContent:       manifestWithAllCodecsAndBandwidths,
 			expectManifestContent: manifestFilter4000To6000BandwidthAndDVH,
 		},
 		{
-			name:                  "when filtering in audio (ec-3) and video (avc) in bandwidth range 4000-6000, expect variants with ac-3, mp4a, hevc, dvh, and/or not in range to be stripped out",
-			filters:               &parsers.MediaFilters{Audios: []parsers.AudioType{"ec-3"}, Videos: []parsers.VideoType{"avc"}, MinBitrate: 4000, MaxBitrate: 6000},
+			name:                  "when filtering in audio (ac-3, mp4a) and video (hevc and dvh) in bandwidth range 4000-6000, expect variants with ac-3, mp4a, hevc, dvh, and/or not in range to be stripped out",
+			filters:               &parsers.MediaFilters{Audios: []parsers.AudioType{"ac-3", "mp4a"}, Videos: []parsers.VideoType{"hvc", "dvh"}, MinBitrate: 4000, MaxBitrate: 6000},
 			manifestContent:       manifestWithAllCodecsAndBandwidths,
 			expectManifestContent: manifestFilter4000To6000BandwidthAndEC3AndAVC,
 		},
 		{
-			name:                  "when filtering in captions (wvtt) in bandwidth range 4000-6000, expect variants with stpp and/or not in range to be stripped out",
-			filters:               &parsers.MediaFilters{CaptionTypes: []parsers.CaptionType{"wvtt"}, MinBitrate: 4000, MaxBitrate: 6000},
+			name:                  "when filtering out captions (stpp) in bandwidth range 4000-6000, expect variants with stpp and/or not in range to be stripped out",
+			filters:               &parsers.MediaFilters{CaptionTypes: []parsers.CaptionType{"stpp"}, MinBitrate: 4000, MaxBitrate: 6000},
 			manifestContent:       manifestWithAllCodecsAndBandwidths,
 			expectManifestContent: manifestFilter4000To6000BandwidthAndWVTT,
 		},
 		{
 			name:                  "when filtering out audio and filtering in bandwidth range 4000-6000, expect variants with ac-3, ec-3, mp4a, and/or not in range to be stripped out",
-			filters:               &parsers.MediaFilters{Audios: []parsers.AudioType{}, MinBitrate: 4000, MaxBitrate: 6000},
+			filters:               &parsers.MediaFilters{Audios: []parsers.AudioType{"ac-3", "ec-3", "mp4a"}, MinBitrate: 4000, MaxBitrate: 6000},
 			manifestContent:       manifestWithAllCodecsAndBandwidths,
 			expectManifestContent: manifestFilter4000To6000BandwidthAndNoAudio,
 		},

--- a/pkg/parsers/urlparser.go
+++ b/pkg/parsers/urlparser.go
@@ -105,6 +105,11 @@ func URLParse(urlpath string) (string, *MediaFilters, error) {
 		switch key := subparts[1]; key {
 		case "v":
 			for _, videoType := range filters {
+				if videoType == "hdr10" {
+					mf.Videos = append(mf.Videos, VideoType("hev1.2"), VideoType("hvc1.2"))
+					continue
+				}
+
 				mf.Videos = append(mf.Videos, VideoType(videoType))
 			}
 		case "a":

--- a/pkg/parsers/urlparser_test.go
+++ b/pkg/parsers/urlparser_test.go
@@ -18,7 +18,7 @@ func TestURLParseUrl(t *testing.T) {
 			"one video type",
 			"/v(hdr10)/",
 			MediaFilters{
-				Videos:     []VideoType{videoHDR10},
+				Videos:     []VideoType{"hev1.2", "hvc1.2"},
 				MaxBitrate: math.MaxInt32,
 				MinBitrate: 0,
 			},
@@ -28,7 +28,7 @@ func TestURLParseUrl(t *testing.T) {
 			"two video types",
 			"/v(hdr10,hevc)/",
 			MediaFilters{
-				Videos:     []VideoType{videoHDR10, videoHEVC},
+				Videos:     []VideoType{"hev1.2", "hvc1.2", videoHEVC},
 				MaxBitrate: math.MaxInt32,
 				MinBitrate: 0,
 			},
@@ -38,7 +38,7 @@ func TestURLParseUrl(t *testing.T) {
 			"two video types and two audio types",
 			"/v(hdr10,hevc)/a(aac,noAd)/",
 			MediaFilters{
-				Videos:     []VideoType{videoHDR10, videoHEVC},
+				Videos:     []VideoType{"hev1.2", "hvc1.2", videoHEVC},
 				Audios:     []AudioType{audioAAC, audioNoAudioDescription},
 				MaxBitrate: math.MaxInt32,
 				MinBitrate: 0,
@@ -49,7 +49,7 @@ func TestURLParseUrl(t *testing.T) {
 			"videos, audio, captions and bitrate range",
 			"/v(hdr10,hevc)/a(aac)/al(pt-BR,en)/c(en)/b(100,4000)/",
 			MediaFilters{
-				Videos:           []VideoType{videoHDR10, videoHEVC},
+				Videos:           []VideoType{"hev1.2", "hvc1.2", videoHEVC},
 				Audios:           []AudioType{audioAAC},
 				AudioLanguages:   []AudioLanguage{audioLangPTBR, audioLangEN},
 				CaptionLanguages: []CaptionLanguage{captionEN},


### PR DESCRIPTION
I have refactored the filters and updated test cases for both hls and dash to be exclusive filters. Meaning a filter like this:

    `http://bakeryhost/a(mp4a)/test.mpd`

Will **REMOVE* any variant/representation for AAC audio. Bitrate filters is still a range of inclusive bandwidths.

I have added a small change to be able to target hdr10. @zsiec was able to find that we can get the profile from the codec string. Essentially we need to get `general_profile_idc` from the codec string which would be the 2 in this case here `hvc1.2.6.L123.50`. The 2 indicates main10 profile.

