### PR TITLE
Propeller url

### DIFF
--- a/docs/_posts/2020-03-05-quick-start.md
+++ b/docs/_posts/2020-03-05-quick-start.md
@@ -24,7 +24,7 @@ Then your `BAKERY_ORIGIN_HOST` was set to `http://streaming.cbsi.video` and your
 
 Bakery can act as a proxy to serve your Propeller channels!
 
-Propeller is the ViacomCBS live-streaming platform. Propeller can orchestrate and manages all of your cloud based resources needed for a live streaming environment. If you have a stream running out of Propeller, you can stream that channel via Bakery! 
+Propeller is the ViacomCBS live-streaming platform. Propeller can orchestrate and manage all of your cloud based resources needed for a live streaming environment. If you have a stream running out of Propeller, you can stream that channel via Bakery! 
 
 
 To play a Propeller channel you can make a Bakery request with the following scheme:

--- a/docs/_posts/2020-03-05-quick-start.md
+++ b/docs/_posts/2020-03-05-quick-start.md
@@ -24,7 +24,7 @@ Then your `BAKERY_ORIGIN_HOST` was set to `http://streaming.cbsi.video` and your
 
 Bakery can act as a proxy to serve your Propeller channels!
 
-Propeller is a live-streaming platform that manages all of your cloud based resources. If you have a stream running out of Propeller, you can stream that channel via Bakery! 
+Propeller is the ViacomCBS live-streaming platform. Propeller can orchestrate and manages all of your cloud based resources needed for a live streaming environment. If you have a stream running out of Propeller, you can stream that channel via Bakery! 
 
 
 To play a Propeller channel you can make a Bakery request with the following scheme:

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ replace github.com/zencoder/go-dash => github.com/cbsinteractive/go-dash v0.0.0-
 go 1.13
 
 require (
-	github.com/cbsinteractive/propeller-client-go v0.0.0-20200320001501-6150907a52b8
+	github.com/cbsinteractive/propeller-client-go v0.0.0-20200325144512-9e4b6cb70b7a
 	github.com/google/go-cmp v0.4.0
 	github.com/grafov/m3u8 v0.11.1
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ replace github.com/zencoder/go-dash => github.com/cbsinteractive/go-dash v0.0.0-
 go 1.13
 
 require (
-	github.com/cbsinteractive/propeller-client-go v0.0.0-20200310001146-17ec5e73de5d
+	github.com/cbsinteractive/propeller-client-go v0.0.0-20200320001501-6150907a52b8
 	github.com/google/go-cmp v0.4.0
 	github.com/grafov/m3u8 v0.11.1
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/cbsinteractive/propeller-client-go v0.0.0-20200319211718-7097ea26d5bc
 github.com/cbsinteractive/propeller-client-go v0.0.0-20200319211718-7097ea26d5bc/go.mod h1:lhWDwJP8cNfWbls5viRm6pAgDsbg1Hmdjpj7TQn5Cfg=
 github.com/cbsinteractive/propeller-client-go v0.0.0-20200320001501-6150907a52b8 h1:cNJVGj0RoVifuy8+dxVAIzZik+XdyfwZQP6tk0Tez9o=
 github.com/cbsinteractive/propeller-client-go v0.0.0-20200320001501-6150907a52b8/go.mod h1:lhWDwJP8cNfWbls5viRm6pAgDsbg1Hmdjpj7TQn5Cfg=
+github.com/cbsinteractive/propeller-client-go v0.0.0-20200325144512-9e4b6cb70b7a h1:vhH+anJpwCzKtjfOof8gBlgE+iun0xEwsL9gcRMCqJ8=
+github.com/cbsinteractive/propeller-client-go v0.0.0-20200325144512-9e4b6cb70b7a/go.mod h1:lhWDwJP8cNfWbls5viRm6pAgDsbg1Hmdjpj7TQn5Cfg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,10 @@ github.com/cbsinteractive/go-dash v0.0.0-20200309174059-c978edf9d310 h1:BZOhTau2
 github.com/cbsinteractive/go-dash v0.0.0-20200309174059-c978edf9d310/go.mod h1:c8Gxxfmh0jmZ6G+ISlpa315WBVkzd8mEhu6gN9mn5Qg=
 github.com/cbsinteractive/propeller-client-go v0.0.0-20200310001146-17ec5e73de5d h1:V61xgXiD0dR2JhFBBCYtsdHceflIaZaau54rpjBIdm8=
 github.com/cbsinteractive/propeller-client-go v0.0.0-20200310001146-17ec5e73de5d/go.mod h1:+5V3mIMEOwqiyb4r3dBsvKtu23kQvJU97Bem9brNzQU=
+github.com/cbsinteractive/propeller-client-go v0.0.0-20200319211718-7097ea26d5bc h1:UFPDXjG2qCDPwtPSiWeUemN5sbjGmlehDbZ7Q2aV1G0=
+github.com/cbsinteractive/propeller-client-go v0.0.0-20200319211718-7097ea26d5bc/go.mod h1:lhWDwJP8cNfWbls5viRm6pAgDsbg1Hmdjpj7TQn5Cfg=
+github.com/cbsinteractive/propeller-client-go v0.0.0-20200320001501-6150907a52b8 h1:cNJVGj0RoVifuy8+dxVAIzZik+XdyfwZQP6tk0Tez9o=
+github.com/cbsinteractive/propeller-client-go v0.0.0-20200320001501-6150907a52b8/go.mod h1:lhWDwJP8cNfWbls5viRm6pAgDsbg1Hmdjpj7TQn5Cfg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/origin/origin.go
+++ b/pkg/origin/origin.go
@@ -34,7 +34,7 @@ func Configure(c config.Config, path string) (Origin, error) {
 		orgID := parts[2]
 		channelID := strings.Split(parts[3], ".")[0] // split off .m3u8
 
-		o, err := NewPropeller(c, orgID, channelID)
+		o, err := NewPropeller(c.Propeller, orgID, channelID)
 		if err != nil {
 			return &Propeller{}, fmt.Errorf("configuring propeller origin: %w", err)
 		}

--- a/pkg/origin/propeller.go
+++ b/pkg/origin/propeller.go
@@ -44,7 +44,7 @@ func getPropellerChannelURL(p config.Propeller, orgID string, channelID string) 
 		return "", fmt.Errorf("fetching channel from propeller: %w", err)
 	}
 
-	return getURL(*channel)
+	return getURL(channel)
 }
 
 func getURL(channel propeller.Channel) (string, error) {


### PR DESCRIPTION
refs #52 

This will handle authentication. The creds are deployed via env vars. To accommodate this change I moved the Propeller Client to be created on startup. I don't think dynamically creating a new client per request is smart anyway.

I've added an internal func for managing the URLs. In order of Ads, Captions, PlaybackURL.

will open a new issue for tracking the work being done by output groups. 