### PR TITLE
Add support for propeller outputs urls

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,8 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: Configure git for private modules
         run: git config --global url."https://${AUTH}@github.com".insteadOf "https://github.com"
+      - name: Don't check checksum of private repo
+        run: go env -w "GONOSUMDB=github.com/cbsinteractive"
       - name: Checkout code
         uses: actions/checkout@v1
       - name: Test

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,6 @@ RUN mkdir -p ~/.ssh && umask 0077 && echo "${SSH_PRIVATE_KEY}" > ~/.ssh/id_rsa \
 	&& git config --global url."git@github.com:".insteadOf https://github.com/ \
 	&& ssh-keyscan github.com >> ~/.ssh/known_hosts
 
-RUN go env -w "GONOSUMDB=github.com/cbsinteractive"
-
 WORKDIR /bakery
 
 COPY go.mod .

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ RUN mkdir -p ~/.ssh && umask 0077 && echo "${SSH_PRIVATE_KEY}" > ~/.ssh/id_rsa \
 	&& git config --global url."git@github.com:".insteadOf https://github.com/ \
 	&& ssh-keyscan github.com >> ~/.ssh/known_hosts
 
+RUN go env -w "GONOSUMDB=github.com/cbsinteractive"
+
 WORKDIR /bakery
 
 COPY go.mod .

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go v1.30.7 // indirect
 	github.com/cbsinteractive/pkg/tracing v0.0.0-20200409233703-f2037b1185c6
 	github.com/cbsinteractive/pkg/xrayutil v0.0.0-20200409233703-f2037b1185c6
-	github.com/cbsinteractive/propeller-go v0.0.0-20200424170524-41b023ada10e
+	github.com/cbsinteractive/propeller-go v0.0.0-20200503222720-e53e98ec6b80
 	github.com/google/go-cmp v0.4.0
 	github.com/grafov/m3u8 v0.11.1
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/handlers/error_test.go
+++ b/handlers/error_test.go
@@ -61,7 +61,7 @@ func TestHandler_ErrorResponse(t *testing.T) {
 			expectErr: ErrorResponse{
 				Message: "failed configuring origin",
 				Errors: map[string][]string{
-					"propeller origin": []string{"request format is not `/propeller/orgID/channelID.m3u8`"},
+					"propeller origin": []string{"invalid url format /propeller/master.m3u8"},
 				},
 			},
 		},

--- a/origin/origin_test.go
+++ b/origin/origin_test.go
@@ -262,7 +262,10 @@ func configMockPropellerAPI() (cfg config.Config, teardown func()) {
 		}
 	}))
 
-	tsURL, _ := url.Parse(ts.URL)
+	tsURL, err := url.Parse(ts.URL)
+	if err != nil {
+		panic(fmt.Sprintf("go httptest server returned invalid url: %v (%v)", ts.URL, err))
+	}
 	cfg = config.Config{LogLevel: "panic"}
 	cfg.Propeller.Client.HostURL = tsURL
 

--- a/origin/origin_test.go
+++ b/origin/origin_test.go
@@ -161,7 +161,7 @@ func TestOrigin_Configure(t *testing.T) {
 		t.Error("Unable to make test urls")
 	}
 
-	cfg, teardown := configMockPropellerAPI()
+	cfg, teardown := configMockPropellerAPI(t)
 	defer teardown()
 
 	tests := []struct {
@@ -236,7 +236,7 @@ func TestOrigin_Configure(t *testing.T) {
 // API that returns hard-coded responses
 //
 // Make sure to call teardown() when the test is over
-func configMockPropellerAPI() (cfg config.Config, teardown func()) {
+func configMockPropellerAPI(tb testing.TB) (cfg config.Config, teardown func()) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.String() {
 		case "/v1/organization/org123/channel/channel-123":
@@ -264,7 +264,7 @@ func configMockPropellerAPI() (cfg config.Config, teardown func()) {
 
 	tsURL, err := url.Parse(ts.URL)
 	if err != nil {
-		panic(fmt.Sprintf("go httptest server returned invalid url: %v (%v)", ts.URL, err))
+		tb.Fatalf("go httptest server returned invalid url: %v (%v)", ts.URL, err)
 	}
 	cfg = config.Config{LogLevel: "panic"}
 	cfg.Propeller.Client.HostURL = tsURL

--- a/origin/propeller.go
+++ b/origin/propeller.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
-	"strings"
 
 	"github.com/sirupsen/logrus"
 
@@ -12,20 +11,23 @@ import (
 	propeller "github.com/cbsinteractive/propeller-go/client"
 )
 
-//Propeller struct holds basic config of a Propeller Channel
-type Propeller struct {
-	URL string
-}
-
-type fetchURL func(*propeller.Client, string, string) (string, error)
-
-// propellerPaths defines the multiple path formats allowed for propeller
-// channels and clips
+// propellerPaths defines the multiple path formats allowed for propeller entities in Bakery
 var propellerPaths = []*regexp.Regexp{
 	regexp.MustCompile(`/propeller/(?P<orgID>.+)/clip/(?P<clipID>.+).m3u8`),
 	regexp.MustCompile(`/propeller/(?P<orgID>.+)/(?P<channelID>.+).m3u8`),
 }
 
+// Propeller Origin holds the URL of a propeller entity (Channel, Clip)
+type Propeller struct {
+	URL string
+}
+
+// configurePropeller builds a new Propeller Origin given the Bakery config and the current url path
+//
+// The path will be matched agains one of propellerPaths patterns to find out the specific entity
+// being requested (channel, clip) and a new Propeller Origin object is returned
+//
+// Return error if 'path' doesn't match with any of propellerPaths
 func configurePropeller(c config.Config, path string) (Origin, error) {
 	urlValues, err := parsePropellerPath(path)
 	if err != nil {
@@ -41,27 +43,20 @@ func configurePropeller(c config.Config, path string) (Origin, error) {
 	channelID := urlValues["channelID"]
 	clipID := urlValues["clipID"]
 
+	var getter urlGetter
 	if clipID != "" {
-		return NewPropeller(c, orgID, clipID, getPropellerClipURL)
+		getter = &clipURLGetter{orgID: orgID, clipID: clipID}
+	} else {
+		getter = &channelURLGetter{orgID: orgID, channelID: channelID}
 	}
-	return NewPropeller(c, orgID, channelID, getPropellerChannelURL)
+	return NewPropeller(c, orgID, channelID, getter)
 }
 
-//GetPlaybackURL will retrieve url
-func (p *Propeller) GetPlaybackURL() string {
-	return p.URL
-}
-
-//FetchManifest will grab manifest contents of configured origin
-func (p *Propeller) FetchManifest(c config.Client) (string, error) {
-	return fetch(c, p.URL)
-}
-
-//NewPropeller returns a propeller struct
-func NewPropeller(c config.Config, orgID string, endpointID string, get fetchURL) (*Propeller, error) {
+// NewPropeller returns a Propeller origin struct
+func NewPropeller(c config.Config, orgID string, endpointID string, getter urlGetter) (*Propeller, error) {
 	c.Propeller.UpdateContext(c.Client.Context)
 
-	propellerURL, err := get(&c.Propeller.Client, orgID, endpointID)
+	propellerURL, err := getter.GetURL(&c.Propeller.Client)
 	if err != nil {
 		err := fmt.Errorf("propeller origin: %w", err)
 		log := c.GetLogger()
@@ -76,6 +71,16 @@ func NewPropeller(c config.Config, orgID string, endpointID string, get fetchURL
 	return &Propeller{
 		URL: propellerURL,
 	}, nil
+}
+
+// GetPlaybackURL will retrieve url
+func (p *Propeller) GetPlaybackURL() string {
+	return p.URL
+}
+
+// FetchManifest will grab manifest contents of configured origin
+func (p *Propeller) FetchManifest(c config.Client) (string, error) {
+	return fetch(c, p.URL)
 }
 
 // parsePropellerPath matches path against all proellerPaths patterns and return a map
@@ -99,64 +104,91 @@ func parsePropellerPath(path string) (map[string]string, error) {
 	return map[string]string{}, errors.New("propeller origin: request format is not `/propeller/orgID/channelID.m3u8`")
 }
 
-func getPropellerChannelURL(client *propeller.Client, orgID string, channelID string) (string, error) {
-	channel, err := client.GetChannel(orgID, channelID)
-	if err != nil {
-		var se propeller.StatusError
-		if errors.As(err, &se) && se.NotFound() {
-			return getPropellerClipURL(client, orgID, fmt.Sprintf("%v-archive", channelID))
-		}
-
-		return "", fmt.Errorf("fetching channel: %w", err)
-	}
-
-	return getChannelURL(channel)
+// propellerClient interface is the subset of methods from propeller-go client used by this module
+type propellerClient interface {
+	GetChannel(orgID string, channelID string) (propeller.Channel, error)
+	GetClip(orgID string, clipID string) (propeller.Clip, error)
 }
 
-func getChannelURL(channel propeller.Channel) (string, error) {
-	//If a channel is "stopped", it will have an #EXT-X-ENDLIST tag
-	//in its manifest, causing the DAI live playlist to 404.
+// urlGetter defines an interface for types that given a Propeller API Client know how to retrieve
+// the playback url of that entity
+type urlGetter interface {
+	GetURL(client propellerClient) (string, error)
+}
+
+// channelURLGetter is a urlGetter for a Propeller channel
+//
+// Finds the channel playback_url using the Propeller API. If the channel is not found try
+// to get the Archive url
+type channelURLGetter struct {
+	orgID     string
+	channelID string
+}
+
+func (g *channelURLGetter) GetURL(client propellerClient) (string, error) {
+	channel, err := client.GetChannel(g.orgID, g.channelID)
+	if err != nil {
+		if g.errChannelNotFound(err) {
+			return g.getArchiveURL(client)
+		}
+		return "", fmt.Errorf("fetching channel: %w", err)
+	}
+	return g.getURL(channel)
+}
+
+func (g *channelURLGetter) errChannelNotFound(err error) bool {
+	var se propeller.StatusError
+	return errors.As(err, &se) && se.NotFound()
+}
+
+func (g *channelURLGetter) getArchiveURL(client propellerClient) (string, error) {
+	clipGetter := &clipURLGetter{
+		orgID:  g.orgID,
+		clipID: fmt.Sprintf("%v-archive", g.channelID),
+	}
+	return clipGetter.GetURL(client)
+}
+
+func (g *channelURLGetter) getURL(channel propeller.Channel) (string, error) {
+	// If a channel is "stopped", it will have an #EXT-X-ENDLIST tag
+	// in its manifest, causing the DAI live playlist to 404.
 	if channel.Ads && channel.Status == "running" {
 		return channel.AdsURL, nil
 	}
-
 	if channel.Captions {
 		return channel.CaptionsURL, nil
 	}
-
 	playbackURL, err := channel.URL()
 	if err != nil {
 		return "", fmt.Errorf("parsing channel url: %w", err)
 	}
-
 	return playbackURL.String(), nil
 }
 
-func getPropellerClipURL(client *propeller.Client, orgID string, clipID string) (string, error) {
-	clip, err := client.GetClip(orgID, clipID)
+// clipURLGetter is a urlGetter for a Propeller clip
+//
+// Finds the Clip playback_url using the Propeller API
+type clipURLGetter struct {
+	orgID  string
+	clipID string
+}
+
+func (g *clipURLGetter) GetURL(client propellerClient) (string, error) {
+	clip, err := client.GetClip(g.orgID, g.clipID)
 	if err != nil {
 		return "", fmt.Errorf("fetching clip: %w", err)
 	}
-
-	return getClipURL(clip)
+	return g.getURL(clip)
 }
 
-func getClipURL(clip propeller.Clip) (string, error) {
+func (g *clipURLGetter) getURL(clip propeller.Clip) (string, error) {
 	playbackURL, err := clip.URL()
 	if err != nil {
 		return "", fmt.Errorf("parsing clip url: %w", err)
 	}
-
 	playback := playbackURL.String()
 	if playback == "" {
 		return playback, fmt.Errorf("clip status: not ready")
 	}
-
 	return playback, nil
-
-}
-
-// extracID will extract the id from manifest name (id.m3u8)
-func extractID(s string) string {
-	return strings.Split(s, ".")[0]
 }

--- a/origin/propeller.go
+++ b/origin/propeller.go
@@ -14,8 +14,8 @@ import (
 // propellerPaths defines the multiple path formats allowed for propeller entities in Bakery
 var propellerPaths = []*regexp.Regexp{
 	regexp.MustCompile(`/propeller/(?P<orgID>.+)/clip/(?P<clipID>.+).m3u8`),
-	regexp.MustCompile(`/propeller/(?P<orgID>.+)/(?P<channelID>.+).m3u8`),
 	regexp.MustCompile(`/propeller/(?P<orgID>.+)/(?P<channelID>.+)/(?P<outputID>.+).m3u8`),
+	regexp.MustCompile(`/propeller/(?P<orgID>.+)/(?P<channelID>.+).m3u8`),
 }
 
 // Propeller Origin holds the URL of a propeller entity (Channel, Clip)

--- a/origin/propeller.go
+++ b/origin/propeller.go
@@ -105,7 +105,7 @@ func parsePropellerPath(path string) (map[string]string, error) {
 		}
 		return values, nil
 	}
-	return map[string]string{}, errors.New("propeller origin: request format is not `/propeller/orgID/channelID.m3u8`")
+	return nil, fmt.Errorf("propeller origin: invalid url format %v", path)
 }
 
 // propellerClient interface is the subset of methods from propeller-go client used by this module

--- a/origin/propeller_test.go
+++ b/origin/propeller_test.go
@@ -1,6 +1,7 @@
 package origin
 
 import (
+	"errors"
 	"testing"
 
 	test "github.com/cbsinteractive/bakery/tests"
@@ -8,60 +9,66 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func getChannel(ads bool, captions bool, play string, status string) propeller.Channel {
-	return propeller.Channel{
-		Ads:         ads,
-		AdsURL:      "some-ad-url.com",
-		Captions:    captions,
-		CaptionsURL: "some-caption-url.com",
-		PlaybackURL: play,
-		Status:      status,
-	}
+// mocks
+
+type mockUrlGetter struct {
+	url string
+	err error
 }
 
-func getClip(status string, desc string, play string) propeller.Clip {
-	return propeller.Clip{
-		Status:            status,
-		StatusDescription: desc,
-		PlaybackURL:       play,
-	}
+func (mock *mockUrlGetter) GetURL(c propellerClient) (string, error) {
+	return mock.url, mock.err
 }
 
-func mockChannelResp(ads, captions bool, play, status string) func(*propeller.Client, string, string) (string, error) {
-	return func(*propeller.Client, string, string) (string, error) {
-		return getChannelURL(getChannel(ads, captions, play, status))
-	}
+type mockPropellerClient struct {
+	// mock return value of GetChannel()
+	getChannel      propeller.Channel
+	getChannelError error
+
+	// mock return value of GetClip()
+	getClip      propeller.Clip
+	getClipError error
+
+	// record last method call
+	getChannelCalled map[string]string
+	getClipCalled    map[string]string
 }
 
-func mockClipResp(status string, desc string, play string) func(*propeller.Client, string, string) (string, error) {
-	return func(*propeller.Client, string, string) (string, error) {
-		return getClipURL(getClip(status, desc, play))
-	}
+func (mock *mockPropellerClient) GetChannel(orgID string, channelID string) (propeller.Channel, error) {
+	mock.getChannelCalled = map[string]string{"orgID": orgID, "channelID": channelID}
+	return mock.getChannel, mock.getChannelError
 }
+func (mock *mockPropellerClient) GetClip(orgID string, clipID string) (propeller.Clip, error) {
+	mock.getClipCalled = map[string]string{"orgID": orgID, "clipID": clipID}
+	return mock.getClip, mock.getClipError
+}
+
+// tests
 
 func TestPropeller_NewPropeller(t *testing.T) {
 	tests := []struct {
 		name      string
-		fetch     fetchURL
+		getter    urlGetter
 		expected  Origin
 		expectErr bool
 	}{
 		{
-			name:     "when creating new propeller channel, expect playbackURL in config",
-			fetch:    mockChannelResp(false, false, "playbackurl.com", "running"),
+			name:     "when creating new propeller channel use urlGetter to get url",
+			getter:   &mockUrlGetter{url: "playbackurl.com"},
 			expected: &Propeller{URL: "playbackurl.com"},
 		},
 		{
-			name:     "when creating new propeller channel, expect playbackURL in config",
-			fetch:    mockClipResp("created", "", "playbackurl.com"),
-			expected: &Propeller{URL: "playbackurl.com"},
+			name:      "when creating new propeller channel return error if urlGetter fails",
+			getter:    &mockUrlGetter{err: errors.New("ops")},
+			expected:  &Propeller{},
+			expectErr: true,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			c := testConfig(test.FakeClient{})
-			got, err := NewPropeller(c, "orgID", "endpointID", tc.fetch)
+			got, err := NewPropeller(c, "orgID", "endpointID", tc.getter)
 			if err != nil && !tc.expectErr {
 				t.Errorf("NewPropeller() didnt expect an error to be returned, got: %v", err)
 				return
@@ -69,182 +76,184 @@ func TestPropeller_NewPropeller(t *testing.T) {
 				t.Error("NewPropeller() expected an error, got nil")
 				return
 			}
-
 			if !cmp.Equal(got, tc.expected) {
 				t.Errorf("Wrong Propeller Origin returned\ngot %v\nexpected: %v\ndiff: %v",
 					got, tc.expected, cmp.Diff(got, tc.expected))
 			}
-
 		})
-
 	}
 }
 
-func TestPropeller_getChannelURL(t *testing.T) {
+func TestPropeller_channelURLGetter(t *testing.T) {
 	tests := []struct {
-		name        string
-		channels    []propeller.Channel
-		expectURL   string
-		expectError bool
-		errStr      string
+		name         string
+		channels     []propeller.Channel
+		expectURL    string
+		expectErrStr string
 	}{
 		{
 			name: "When ads are set, ad url is returned when channel is running and regardless of other values",
 			channels: []propeller.Channel{
-				getChannel(true, false, "who cares", "running"),
-				getChannel(true, true, "who cares again", "running"),
+				{Ads: true, AdsURL: "ad-url.com", Status: "running"},
+				{Ads: true, AdsURL: "ad-url.com", Status: "running", Captions: true, CaptionsURL: "caption-url.com"},
+				{Ads: true, AdsURL: "ad-url.com", Status: "running", PlaybackURL: "playback.com"},
 			},
-			expectURL: "some-ad-url.com",
+			expectURL: "ad-url.com",
 		},
 		{
 			name: "When ads are false and captions are set, ad url is returned regardless of other values",
 			channels: []propeller.Channel{
-				getChannel(false, true, "who cares", "running"),
-				getChannel(false, true, "who cares again", "running"),
+				{Captions: true, CaptionsURL: "caption-url.com"},
+				{Captions: true, CaptionsURL: "caption-url.com", AdsURL: "some-ad-url.com", PlaybackURL: "playback.com"},
 			},
-			expectURL: "some-caption-url.com",
+			expectURL: "caption-url.com",
 		},
 		{
 			name: "When ads and captions are NOT set, playback url is returned",
 			channels: []propeller.Channel{
-				getChannel(false, false, "playback-url.com", "running"),
+				{PlaybackURL: "playback-url.com"},
 			},
 			expectURL: "playback-url.com",
 		},
-
 		{
 			name: "When ads are set but channel isn't running, return playbackURL",
 			channels: []propeller.Channel{
-				getChannel(true, false, "playback-url.com", "stopping"),
-				getChannel(true, false, "playback-url.com", "ready"),
-				getChannel(true, false, "playback-url.com", "pending"),
-				getChannel(true, false, "playback-url.com", "starting"),
+				{Ads: true, AdsURL: "ad-url.com", PlaybackURL: "playback-url.com", Status: "stopping"},
+				{Ads: true, AdsURL: "ad-url.com", PlaybackURL: "playback-url.com", Status: "ready"},
+				{Ads: true, AdsURL: "ad-url.com", PlaybackURL: "playback-url.com", Status: "pending"},
+				{Ads: true, AdsURL: "ad-url.com", PlaybackURL: "playback-url.com", Status: "starting"},
 			},
 			expectURL: "playback-url.com",
 		},
 		{
 			name: "When ads, captions, and playbackURL are NOT set, error is thrown",
 			channels: []propeller.Channel{
-				getChannel(false, false, "", "running"),
+				{},
 			},
-			expectURL:   "",
-			expectError: true,
-			errStr:      "parsing channel url: Channel not ready",
+			expectErrStr: "parsing channel url: Channel not ready",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			for _, channel := range tc.channels {
-				u, err := getChannelURL(channel)
+				client := &mockPropellerClient{getChannel: channel}
+				getter := &channelURLGetter{orgID: "org", channelID: "ch123"}
+				u, err := getter.GetURL(client)
 
-				// pending and error status channels should return error
-				if err != nil && !tc.expectError {
-					t.Errorf("getChannelURL() didn't expect an error, got %v", err)
-				} else if err == nil && tc.expectError {
-					t.Errorf("getChannelURL() expected error, got nil")
+				if err != nil && tc.expectErrStr == "" {
+					t.Errorf("channelURLGetter.GetURL() didn't expect an error, got %v", err)
+				} else if err == nil && tc.expectErrStr != "" {
+					t.Errorf("channelURLGetter.GetURL() expected error, got nil")
+				} else if err != nil && err.Error() != tc.expectErrStr {
+					t.Errorf("channelURLGetter.GetURL() got wrong error. expected: %q, got %q", tc.expectErrStr, err.Error())
 				}
-
-				if tc.expectError && err.Error() != tc.errStr {
-					t.Errorf("Wrong error string. expected: %q, got %q", tc.errStr, err.Error())
-				}
-
 				if tc.expectURL != u {
-					t.Errorf("Wrong playback url: expect: %q, got %q", tc.expectURL, u)
+					t.Errorf("channelURLGetter.GetURL() got wrong playback url: expect: %q, got %q", tc.expectURL, u)
+				}
+				if client.getChannelCalled["orgID"] != "org" || client.getChannelCalled["channelID"] != "ch123" {
+					t.Errorf("channelURLGetter.GetURL() called client.GetChannel() with wrong arguments: %#v", client.getChannelCalled)
 				}
 			}
 		})
-
 	}
 }
 
-func TestPropeller_getClipURL(t *testing.T) {
+func TestPropeller_channelURLGetter_getClipArchiveIfChannelNotFound(t *testing.T) {
+	client := &mockPropellerClient{
+		getChannelError: propeller.StatusError{Code: 404},
+		getClip:         propeller.Clip{PlaybackURL: "archive-url.com"},
+	}
+	getter := &channelURLGetter{orgID: "org", channelID: "ch123"}
+
+	u, err := getter.GetURL(client)
+	if err != nil {
+		t.Fatalf("returned unexpected error: %q", err)
+	}
+	if u != "archive-url.com" {
+		t.Fatalf("got wrong url %q", u)
+	}
+	if client.getChannelCalled["orgID"] != "org" || client.getChannelCalled["channelID"] != "ch123" {
+		t.Errorf("client.GetChannel() with wrong arguments: %#v", client.getChannelCalled)
+	}
+	if client.getClipCalled["orgID"] != "org" || client.getClipCalled["clipID"] != "ch123-archive" {
+		t.Errorf("client.GetClip() with wrong arguments: %#v", client.getClipCalled)
+	}
+}
+
+func TestPropeller_channelURLGetter_getClipArchiveError(t *testing.T) {
+	client := &mockPropellerClient{
+		getChannelError: propeller.StatusError{Code: 404},
+		getClipError:    errors.New("fail to get archive"),
+	}
+	getter := &channelURLGetter{orgID: "org", channelID: "ch123"}
+
+	u, err := getter.GetURL(client)
+	if err == nil {
+		t.Fatalf("should return error, got nil")
+	}
+	if err.Error() != "fetching clip: fail to get archive" {
+		t.Fatalf("returned wrong error: %q", err)
+	}
+	if u != "" {
+		t.Fatalf("got url %q", u)
+	}
+	if client.getChannelCalled["orgID"] != "org" || client.getChannelCalled["channelID"] != "ch123" {
+		t.Errorf("client.GetChannel() with wrong arguments: %#v", client.getChannelCalled)
+	}
+	if client.getClipCalled["orgID"] != "org" || client.getClipCalled["clipID"] != "ch123-archive" {
+		t.Errorf("client.GetClip() with wrong arguments: %#v", client.getClipCalled)
+	}
+}
+
+func TestPropeller_clipURLGetter(t *testing.T) {
 	tests := []struct {
-		name        string
-		clip        propeller.Clip
-		expectURL   string
-		expectError bool
-		errStr      string
+		name         string
+		clip         propeller.Clip
+		expectURL    string
+		expectErrStr string
 	}{
 		{
 			name:      "When status is created, expect playback url",
-			clip:      getClip("created", "", "playback-url.com"),
+			clip:      propeller.Clip{Status: "created", PlaybackURL: "playback-url.com"},
 			expectURL: "playback-url.com",
 		},
 		{
-			name:        "When status is created, but no playbackURL available, expect error not ready",
-			clip:        getClip("created", "", ""),
-			expectURL:   "",
-			expectError: true,
-			errStr:      "clip status: not ready",
+			name:         "When status is created, but no playbackURL available, expect error not ready",
+			clip:         propeller.Clip{Status: "created"},
+			expectErrStr: "clip status: not ready",
 		},
 		{
-			name:        "When status is error, expect error",
-			clip:        getClip("error", "some failure description", "who cares again"),
-			expectURL:   "",
-			expectError: true,
-			errStr:      "parsing clip url: some failure description",
+			name:         "When status is error, expect error",
+			clip:         propeller.Clip{Status: "error", StatusDescription: "some failure description", PlaybackURL: "who-cares.com"},
+			expectErrStr: "parsing clip url: some failure description",
 		},
 		{
-			name:        "When status is pending, expect clip not ready error",
-			clip:        getClip("pending", "", "who cares"),
-			expectURL:   "",
-			expectError: true,
-			errStr:      "parsing clip url: Clip not ready",
+			name:         "When status is pending, expect clip not ready error",
+			clip:         propeller.Clip{Status: "pending", PlaybackURL: "who cares"},
+			expectErrStr: "parsing clip url: Clip not ready",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			u, err := getClipURL(tc.clip)
+			client := &mockPropellerClient{getClip: tc.clip}
+			getter := &clipURLGetter{orgID: "org", clipID: "cl123"}
+			u, err := getter.GetURL(client)
 
-			if err != nil && !tc.expectError {
-				t.Errorf("getClipURL() didn't expect an error, got %v", err)
-			} else if err == nil && tc.expectError {
-				t.Errorf("getClipURL() expected error, got nil")
+			if err != nil && tc.expectErrStr == "" {
+				t.Errorf("clipURLGetter.GetURL() didn't expect an error, got %v", err)
+			} else if err == nil && tc.expectErrStr != "" {
+				t.Errorf("clipURLGetter.GetURL() expected error, got nil")
+			} else if err != nil && err.Error() != tc.expectErrStr {
+				t.Errorf("clipURLGetter.GetURL() got wrong error. expected: %q, got %q", tc.expectErrStr, err.Error())
 			}
-
-			if tc.expectError && err.Error() != tc.errStr {
-				t.Errorf("Wrong error string. expected: %q, got %q", tc.errStr, err.Error())
-			}
-
 			if tc.expectURL != u {
-				t.Errorf("Wrong playback url: expect: %q, got %q", tc.expectURL, u)
+				t.Errorf("clipURLGetter.GetURL() got Wrong playback url: expect: %q, got %q", tc.expectURL, u)
+			}
+			if client.getClipCalled["orgID"] != "org" || client.getClipCalled["clipID"] != "cl123" {
+				t.Errorf("clipURLGetter.GetURL() called client.GetClip() with wrong arguments: %#v", client.getClipCalled)
 			}
 		})
-
-	}
-}
-
-func TestPropeller_extractID(t *testing.T) {
-	tests := []struct {
-		name       string
-		manifest   []string
-		expectedID []string
-	}{
-		{
-			name: "When extracting ids from manifest path, return correct id",
-			manifest: []string{
-				"id.m3u8",
-				"id",
-			},
-			expectedID: []string{
-				"id",
-				"id",
-			},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			for i, m := range tc.manifest {
-				got := extractID(m)
-
-				if got != tc.expectedID[i] {
-					t.Errorf("Wrong ID reurned. expect: %v, got %v", tc.expectedID[i], got)
-				}
-			}
-		})
-
 	}
 }

--- a/origin/propeller_test.go
+++ b/origin/propeller_test.go
@@ -144,7 +144,7 @@ func TestPropeller_channelURLGetter(t *testing.T) {
 				if err != nil && tc.expectErrStr == "" {
 					t.Errorf("channelURLGetter.GetURL() didn't expect an error, got %v", err)
 				} else if err == nil && tc.expectErrStr != "" {
-					t.Errorf("channelURLGetter.GetURL() expected error, got nil")
+					t.Error("channelURLGetter.GetURL() expected error, got nil")
 				} else if err != nil && err.Error() != tc.expectErrStr {
 					t.Errorf("channelURLGetter.GetURL() got wrong error. expected: %q, got %q", tc.expectErrStr, err.Error())
 				}
@@ -213,7 +213,7 @@ func TestPropeller_channelURLGetter_getArchive(t *testing.T) {
 			if err != nil && tc.expectErrStr == "" {
 				t.Errorf("returned unexpected error: %q", err)
 			} else if err == nil && tc.expectErrStr != "" {
-				t.Errorf("expected error, got nil")
+				t.Error("expected error, got nil")
 			} else if err != nil && err.Error() != tc.expectErrStr {
 				t.Errorf("got wrong error. expected: %q, got %q", tc.expectErrStr, err.Error())
 			}


### PR DESCRIPTION
Propeller added support for multiple outputs (https://github.com/cbsinteractive/propeller/pull/895)

Right now bakery support the following URLs:
```
/propeller/orgID/channelID.m3u8
/propeller/orgID/clip/clipID.m3u8
```
this change will add support for
```
/propeller/orgID/channelID/outputID.m3u8
```

Required change on propeller-go client: https://github.com/cbsinteractive/propeller-go/pull/4

**Note on tests**

The first commit in this PR adds some tests for `origin.Configure()` 
for propeller endpoints. The test starts a fake Propeller API with stubbed
responses allowing origin.NewPropeller() to interact with the API
and build a `origin.Propeller` object

For situations like this I usually prefer to mock the go client itself,
but Bajery used uses a reference to `*propeller.Client` which makes it
harder to replace for tests. We could refactor that into an interface,
if Bakery works with a `propeller.Client` interface then it's easy to swap
with a mock implementation for tests.

I didn't want to do any design changes before adding support for
propeller outputs urls. So this test helps increase coverage for
`origin.NewPropeller()`