### PR TITLE
logging: consolidate logs

### DIFF
--- a/cmd/http/main.go
+++ b/cmd/http/main.go
@@ -19,9 +19,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	middleware := c.SetupMiddleware()
-	authMiddleware := c.AuthMiddlewareFrom(middleware)
-	handler := authMiddleware.Then(handlers.LoadHandler(c))
+	handler := c.SetupMiddleware().Then(handlers.LoadHandler(c))
 
 	c.Logger.Info().Str("port", c.Listen).Msg("Starting Bakery")
 	http.Handle("/", c.Client.Tracer.Handle(tracing.FixedNamer("bakery"), handler))

--- a/config/config.go
+++ b/config/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/cbsinteractive/bakery/logging"
 	"github.com/justinas/alice"
 	"github.com/kelseyhightower/envconfig"
 	"github.com/rs/zerolog"
@@ -108,9 +109,7 @@ func (c Config) authMiddleware() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.Header.Get(c.OriginKey) != c.OriginToken {
-				hlog.FromRequest(r).UpdateContext(func(zctx zerolog.Context) zerolog.Context {
-					return zctx.Interface("headers", r.Header).Str("error", "failed authenticating request")
-				})
+				logging.UpdateCtx(r.Context(), logging.Params{"headers": r.Header, "error": "failed authenticating request"})
 
 				http.Error(w, fmt.Sprintf("you must pass a valid api token as %q", c.OriginKey),
 					http.StatusForbidden)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -244,9 +244,7 @@ func TestConfig_Middleware(t *testing.T) {
 
 	c := getDefaultConfig(defaultClientConfig, disabledTraceConfig, Propeller{})
 
-	middleware := c.SetupMiddleware()
-	authMiddleware := c.AuthMiddlewareFrom(middleware)
-	handler := authMiddleware.Then(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	handler := c.SetupMiddleware().Then(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 

--- a/handlers/error.go
+++ b/handlers/error.go
@@ -1,11 +1,13 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 
-	"github.com/rs/zerolog"
+	"github.com/cbsinteractive/bakery/logging"
 )
 
 //ErrorResponse holds the errore response message
@@ -33,13 +35,9 @@ func NewErrorResponse(message string, err error) ErrorResponse {
 }
 
 // HandleError will both log and handle the http error for a given error response
-func (e *ErrorResponse) HandleError(log zerolog.Logger, w http.ResponseWriter, code int) {
-	logError(log, e.Message, e.Err)
+func (e *ErrorResponse) HandleError(ctx context.Context, w http.ResponseWriter, code int) {
+	logging.UpdateCtx(ctx, logging.Params{"error": fmt.Sprintf("%s: %v", e.Message, e.Err)})
 	httpError(w, code, *e)
-}
-
-func logError(log zerolog.Logger, message string, err error) {
-	log.Err(err).Str("pkg", "test").Msgf(message)
 }
 
 func httpError(w http.ResponseWriter, code int, e ErrorResponse) {

--- a/handlers/error_test.go
+++ b/handlers/error_test.go
@@ -118,9 +118,7 @@ func TestHandler_ErrorResponse(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			c := testConfig(test.MockClient(tc.mockResp))
-			middleware := c.SetupMiddleware()
-			authMiddleware := c.AuthMiddlewareFrom(middleware)
-			handler := authMiddleware.Then(LoadHandler(c))
+			handler := c.SetupMiddleware().Then(LoadHandler(c))
 			// set req + response recorder and serve it
 			req := getRequest(tc.url, t)
 			req.Header.Set("x-bakery-origin-token", tc.auth)

--- a/logging/context.go
+++ b/logging/context.go
@@ -1,0 +1,19 @@
+package logging
+
+import (
+	"context"
+
+	"github.com/rs/zerolog"
+)
+
+type Params map[string]interface{}
+
+func UpdateCtx(ctx context.Context, p Params) {
+	log := zerolog.Ctx(ctx)
+	log.UpdateContext(func(c zerolog.Context) zerolog.Context {
+		for k, v := range p {
+			c = c.Interface(k, v)
+		}
+		return c
+	})
+}

--- a/origin/origin.go
+++ b/origin/origin.go
@@ -26,9 +26,9 @@ type DefaultOrigin struct {
 }
 
 //Configure will return proper Origin interface
-func Configure(c config.Config, path string) (Origin, error) {
+func Configure(ctx context.Context, c config.Config, path string) (Origin, error) {
 	if strings.Contains(path, "propeller") {
-		return configurePropeller(c, path)
+		return configurePropeller(ctx, c, path)
 	}
 
 	//check if rendition URL
@@ -36,11 +36,7 @@ func Configure(c config.Config, path string) (Origin, error) {
 	if len(parts) == 2 { //["", "base64.m3u8"]
 		variantURL, err := decodeVariantURL(parts[1])
 		if err != nil {
-			err := fmt.Errorf("decoding variant manifest url: %w", err)
-			c.Logger.Err(err).
-				Str("origin", "propeller").
-				Msgf("can't decode url %v", path)
-			return &DefaultOrigin{}, err
+			return &DefaultOrigin{}, fmt.Errorf("decoding variant manifest url %q: %w", path, err)
 		}
 		path = variantURL
 	}

--- a/origin/origin_test.go
+++ b/origin/origin_test.go
@@ -231,7 +231,7 @@ func TestOrigin_Configure(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := Configure(tc.c, tc.path)
+			got, err := Configure(context.Background(), tc.c, tc.path)
 
 			if err != nil && !tc.expectErr {
 				t.Errorf("Configure() didnt expect an error to be returned, got: %q", err)

--- a/origin/propeller.go
+++ b/origin/propeller.go
@@ -49,14 +49,15 @@ func configurePropeller(ctx context.Context, c config.Config, path string) (Orig
 	outputID := urlValues[outputIDKey]
 	clipID := urlValues[clipIDKey]
 
-	logging.UpdateCtx(ctx, logging.Params{orgIDKey: orgID, channelIDKey: channelID, outputIDKey: outputID, clipIDKey: clipID})
-
 	var getter urlGetter
 	if clipID != "" {
+		logging.UpdateCtx(ctx, logging.Params{orgIDKey: orgID, clipIDKey: clipID})
 		getter = &clipURLGetter{orgID: orgID, clipID: clipID}
 	} else if outputID != "" {
+		logging.UpdateCtx(ctx, logging.Params{orgIDKey: orgID, channelIDKey: channelID, outputIDKey: outputID})
 		getter = &outputURLGetter{orgID: orgID, channelID: channelID, outputID: outputID}
 	} else {
+		logging.UpdateCtx(ctx, logging.Params{orgIDKey: orgID, channelIDKey: channelID})
 		getter = &channelURLGetter{orgID: orgID, channelID: channelID}
 	}
 	return NewPropeller(ctx, c, getter)

--- a/origin/propeller.go
+++ b/origin/propeller.go
@@ -1,19 +1,28 @@
 package origin
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"regexp"
 
 	"github.com/cbsinteractive/bakery/config"
+	"github.com/cbsinteractive/bakery/logging"
 	propeller "github.com/cbsinteractive/propeller-go/client"
+)
+
+const (
+	orgIDKey     = "orgID"
+	clipIDKey    = "clipID"
+	channelIDKey = "channelID"
+	outputIDKey  = "outputID"
 )
 
 // propellerPaths defines the multiple path formats allowed for propeller entities in Bakery
 var propellerPaths = []*regexp.Regexp{
-	regexp.MustCompile(`/propeller/(?P<orgID>.+)/clip/(?P<clipID>.+).m3u8`),
-	regexp.MustCompile(`/propeller/(?P<orgID>.+)/(?P<channelID>.+)/(?P<outputID>.+).(m3u8|mpd)`),
-	regexp.MustCompile(`/propeller/(?P<orgID>.+)/(?P<channelID>.+).(m3u8|mpd)`),
+	regexp.MustCompile(`/propeller/(?P<` + orgIDKey + `>.+)/clip/(?P<` + clipIDKey + `>.+).m3u8`),
+	regexp.MustCompile(`/propeller/(?P<` + orgIDKey + `>.+)/(?P<` + channelIDKey + `>.+)/(?P<` + outputIDKey + `>.+).(m3u8|mpd)`),
+	regexp.MustCompile(`/propeller/(?P<` + orgIDKey + `>.+)/(?P<` + channelIDKey + `>.+).(m3u8|mpd)`),
 }
 
 // Propeller Origin holds the URL of a propeller entity (Channel, Clip)
@@ -23,52 +32,43 @@ type Propeller struct {
 
 // configurePropeller builds a new Propeller Origin given the Bakery config and the current url path
 //
-// The path will be matched agains one of propellerPaths patterns to find out the specific entity
+// The path will be matched against one of propellerPaths patterns to find out the specific entity
 // being requested (channel, clip) and a new Propeller Origin object is returned
 //
 // Return error if 'path' doesn't match with any of propellerPaths
-func configurePropeller(c config.Config, path string) (Origin, error) {
+func configurePropeller(ctx context.Context, c config.Config, path string) (Origin, error) {
+	logging.UpdateCtx(ctx, logging.Params{"origin": "propeller"})
+
 	urlValues, err := parsePropellerPath(path)
 	if err != nil {
-		c.Logger.Err(err).
-			Str("origin", "propeller").
-			Str("request", path).
-			Msgf("can't configure propeller from requested path %v", path)
 		return &Propeller{}, err
 	}
 
-	orgID := urlValues["orgID"]
-	channelID := urlValues["channelID"]
-	outputID := urlValues["outputID"]
-	clipID := urlValues["clipID"]
+	orgID := urlValues[orgIDKey]
+	channelID := urlValues[channelIDKey]
+	outputID := urlValues[outputIDKey]
+	clipID := urlValues[clipIDKey]
 
-	ctxLog := c.Logger.With().Str("org-id", orgID).Str("channel-id", channelID).Logger()
+	logging.UpdateCtx(ctx, logging.Params{orgIDKey: orgID, channelIDKey: channelID, outputIDKey: outputID, clipIDKey: clipID})
+
 	var getter urlGetter
 	if clipID != "" {
-		ctxLog.Info().Str("clip-id", clipID).Msg("configuring clip")
 		getter = &clipURLGetter{orgID: orgID, clipID: clipID}
 	} else if outputID != "" {
-		ctxLog.Info().Str("output-id", outputID).Msg("configuring output")
 		getter = &outputURLGetter{orgID: orgID, channelID: channelID, outputID: outputID}
 	} else {
-		ctxLog.Info().Msg("configuring channel")
 		getter = &channelURLGetter{orgID: orgID, channelID: channelID}
 	}
-	return NewPropeller(c, orgID, getter)
+	return NewPropeller(ctx, c, getter)
 }
 
 // NewPropeller returns a Propeller origin struct
-func NewPropeller(c config.Config, orgID string, getter urlGetter) (*Propeller, error) {
+func NewPropeller(ctx context.Context, c config.Config, getter urlGetter) (*Propeller, error) {
 	c.Propeller.UpdateContext(c.Client.Context)
 
 	propellerURL, err := getter.GetURL(&c.Propeller.Client)
 	if err != nil {
-		err := fmt.Errorf("propeller origin: %w", err)
-		c.Logger.Err(err).
-			Str("origin", "propeller").
-			Str("org-id", orgID).
-			Msg("fetching propeller channel")
-		return &Propeller{}, err
+		return &Propeller{}, fmt.Errorf("fetching propeller channel: %w", err)
 	}
 
 	return &Propeller{

--- a/origin/propeller_test.go
+++ b/origin/propeller_test.go
@@ -1,6 +1,7 @@
 package origin
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -68,7 +69,7 @@ func TestPropeller_NewPropeller(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			c := testConfig(test.FakeClient{})
-			got, err := NewPropeller(c, "orgID", tc.getter)
+			got, err := NewPropeller(context.Background(), c, tc.getter)
 			if err != nil && !tc.expectErr {
 				t.Errorf("NewPropeller() didnt expect an error to be returned, got: %v", err)
 				return


### PR DESCRIPTION
Collapses all logging to a single line per request, enrich the logging context with data as it becomes available.