### PR TITLE
extend propeller docs to include outputs. fix the themes issues

### DIFF
--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -53,14 +53,18 @@ a:not([class]) {
   font-size: 0.9rem;
 }
 
-.navigation-list-link.active{
-    color: #ffffff;
+.site-title:hover {
+  background-image: none;
 }
 
-.navigation-list-child-list .navigation-list-link {
-    color: #bdbbc0;
+.nav-list .nav-list-item .nav-list-link:hover, .nav-list .nav-list-item .nav-list-link.active {
+  background-image: none;
+}
 
-    &.active {
-        color: #ffffff;
-    }
+.nav-list .nav-list-item > .nav-list .nav-list-item .nav-list-link {
+  color: #bdbbc0;
+
+  &.active {
+    color: #ffffff;
+  }
 }

--- a/docs/propeller/index.md
+++ b/docs/propeller/index.md
@@ -37,6 +37,15 @@ To request a Propeller clip via Bakery:
 
     https://bakery.dev.cbsi.video/propeller/<org-id>/clip/<clip-id>.m3u8
 
+**Note** Clips are not enabled for DASH
+
+### Outputs
+
+To request a Propeller output via Bakery:
+
+    https://bakery.dev.cbsi.video/propeller/<org-id>/<channel-id>/<output-id>.m3u8
+
+**Note** Outputs are not currently enabled for DASH but a feature implementation is in the backlog. To prioritize this feature, feel free to reach out on slack!
 
 
 ## Help


### PR DESCRIPTION
Just The Docs, the template we use for our themes made some [changes](https://pmarsceill.github.io/just-the-docs/docs/customization/#override-and-completely-custom-styles) in how we are able to apply custom themes. 

In essence, just move your themes from  `_sass/override.scss` to `_sass/custom/custom.scss`

Changes were also made to HTML elements so you may need to rename some elements in the sass file. One example is renaming a part of the element from `navigation` -> `nav`

