### PR TITLE
fhe: fix panic for rendition manifests without trim filter (fixes #139)

### DIFF
--- a/filters/hls.go
+++ b/filters/hls.go
@@ -408,6 +408,10 @@ func (h *HLSFilter) filterRenditionManifest(filters *parsers.MediaFilters, m *m3
 		return "", fmt.Errorf("filtering Rendition Manifest: %w", err)
 	}
 
+	if filters.Trim == nil {
+		return isEmpty(m.Encode().String())
+	}
+
 	// timestamps in milliseconds
 	startFilter := filters.Trim.Start * 1000
 	endFilter := filters.Trim.End * 1000

--- a/filters/hls.go
+++ b/filters/hls.go
@@ -65,7 +65,10 @@ func (h *HLSFilter) FilterContent(ctx context.Context, filters *parsers.MediaFil
 	}
 
 	if manifestType != m3u8.MASTER {
-		return h.filterRenditionManifest(filters, m.(*m3u8.MediaPlaylist))
+		if filters.Trim != nil {
+			return h.trimRenditionManifest(filters, m.(*m3u8.MediaPlaylist))
+		}
+		return isEmpty(m.Encode().String())
 	}
 
 	// convert into the master playlist type
@@ -402,14 +405,10 @@ func isRelative(urlStr string) (bool, error) {
 
 // FilterRenditionManifest will be responsible for filtering the manifest
 // according  to the MediaFilters
-func (h *HLSFilter) filterRenditionManifest(filters *parsers.MediaFilters, m *m3u8.MediaPlaylist) (string, error) {
+func (h *HLSFilter) trimRenditionManifest(filters *parsers.MediaFilters, m *m3u8.MediaPlaylist) (string, error) {
 	filteredPlaylist, err := m3u8.NewMediaPlaylist(m.Count(), m.Count())
 	if err != nil {
 		return "", fmt.Errorf("filtering Rendition Manifest: %w", err)
-	}
-
-	if filters.Trim == nil {
-		return isEmpty(m.Encode().String())
 	}
 
 	// timestamps in milliseconds


### PR DESCRIPTION
with this PR, the bug present on #139 is no longer reproducible:

```
% http 'http://localhost:8080/phe(true)/aHR0cHM6Ly9kaWN0YTU0ODczYTIuYWlyc3BhY2UtY2RuLmNic2l2aWRlby5jb20va2VpdGhoOTdoLXRlc3QvZjFlOGUwOGEwZjk2NDkyMzk0ZjRkYmM3YjhjMjJhZGQvZW4ubTN1OA.m3u8'
HTTP/1.1 200 OK
Access-Control-Allow-Origin: *
Content-Length: 1813
Content-Type: application/x-mpegURL
Date: Tue, 02 Mar 2021 13:07:14 GMT
Request-Id: c0v3h0gi7qkn19d4qtc0

#EXTM3U
#EXT-X-VERSION:3
#EXT-X-MEDIA-SEQUENCE:17738
#EXT-X-TARGETDURATION:8
#EXT-X-PROGRAM-DATE-TIME:2021-02-23T05:59:55.633Z
#EXTINF:6.000,
http://bakery.cbsi.video/phe(true)/aHR0cHM6Ly9kaWN0YTU0ODczYTIuYWlyc3BhY2UtY2RuLmNic2l2aWRlby5jb20va2VpdGhoOTdoLXRlc3QvZW4vY2FwdGlvbnNfMTc3MzgudnR0.vtt
#EXT-X-PROGRAM-DATE-TIME:2021-02-23T06:00:01.633Z
#EXTINF:6.000,
http://bakery.cbsi.video/phe(true)/aHR0cHM6Ly9kaWN0YTU0ODczYTIuYWlyc3BhY2UtY2RuLmNic2l2aWRlby5jb20va2VpdGhoOTdoLXRlc3QvZW4vY2FwdGlvbnNfMTc3MzkudnR0.vtt
#EXT-X-PROGRAM-DATE-TIME:2021-02-23T06:00:07.633Z
#EXTINF:6.000,
http://bakery.cbsi.video/phe(true)/aHR0cHM6Ly9kaWN0YTU0ODczYTIuYWlyc3BhY2UtY2RuLmNic2l2aWRlby5jb20va2VpdGhoOTdoLXRlc3QvZW4vY2FwdGlvbnNfMTc3NDAudnR0.vtt
#EXT-X-PROGRAM-DATE-TIME:2021-02-23T06:00:13.633Z
#EXTINF:6.000,
http://bakery.cbsi.video/phe(true)/aHR0cHM6Ly9kaWN0YTU0ODczYTIuYWlyc3BhY2UtY2RuLmNic2l2aWRlby5jb20va2VpdGhoOTdoLXRlc3QvZW4vY2FwdGlvbnNfMTc3NDEudnR0.vtt
#EXT-X-PROGRAM-DATE-TIME:2021-02-23T06:00:19.633Z
#EXTINF:6.000,
http://bakery.cbsi.video/phe(true)/aHR0cHM6Ly9kaWN0YTU0ODczYTIuYWlyc3BhY2UtY2RuLmNic2l2aWRlby5jb20va2VpdGhoOTdoLXRlc3QvZW4vY2FwdGlvbnNfMTc3NDIudnR0.vtt
#EXT-X-PROGRAM-DATE-TIME:2021-02-23T06:00:25.633Z
#EXTINF:6.000,
http://bakery.cbsi.video/phe(true)/aHR0cHM6Ly9kaWN0YTU0ODczYTIuYWlyc3BhY2UtY2RuLmNic2l2aWRlby5jb20va2VpdGhoOTdoLXRlc3QvZW4vY2FwdGlvbnNfMTc3NDMudnR0.vtt
#EXT-X-PROGRAM-DATE-TIME:2021-02-23T06:00:31.633Z
#EXTINF:6.000,
http://bakery.cbsi.video/phe(true)/aHR0cHM6Ly9kaWN0YTU0ODczYTIuYWlyc3BhY2UtY2RuLmNic2l2aWRlby5jb20va2VpdGhoOTdoLXRlc3QvZW4vY2FwdGlvbnNfMTc3NDQudnR0.vtt
#EXT-X-PROGRAM-DATE-TIME:2021-02-23T06:00:37.633Z
#EXTINF:6.000,
http://bakery.cbsi.video/phe(true)/aHR0cHM6Ly9kaWN0YTU0ODczYTIuYWlyc3BhY2UtY2RuLmNic2l2aWRlby5jb20va2VpdGhoOTdoLXRlc3QvZW4vY2FwdGlvbnNfMTc3NDUudnR0.vtt
```

Trim filter + fhe():

```
% http "http://localhost:8080/phe(true)/t(161406008,1614060020)/aHR0cHM6Ly9kaWN0YTU0ODczYTIuYWlyc3BhY2UtY2RuLmNic2l2aWRlby5jb20va2VpdGhoOTdoLXRlc3QvZjFlOGUwOGEwZjk2NDkyMzk0ZjRkYmM3YjhjMjJhZGQvZW4ubTN1OA.m3u8"
HTTP/1.1 200 OK
Access-Control-Allow-Origin: *
Cache-Control: max-age=3
Content-Length: 1173
Content-Type: application/x-mpegURL
Date: Tue, 02 Mar 2021 13:11:09 GMT
Request-Id: c0v3ir0i7qkn19d4qtgg

#EXTM3U
#EXT-X-VERSION:3
#EXT-X-MEDIA-SEQUENCE:0
#EXT-X-TARGETDURATION:6
#EXT-X-PROGRAM-DATE-TIME:2021-02-23T05:59:55.633Z
#EXTINF:6.000,
http://bakery.cbsi.video/phe(true)/aHR0cHM6Ly9kaWN0YTU0ODczYTIuYWlyc3BhY2UtY2RuLmNic2l2aWRlby5jb20va2VpdGhoOTdoLXRlc3QvZW4vY2FwdGlvbnNfMTc3MzgudnR0.vtt
#EXT-X-PROGRAM-DATE-TIME:2021-02-23T06:00:01.633Z
#EXTINF:6.000,
http://bakery.cbsi.video/phe(true)/aHR0cHM6Ly9kaWN0YTU0ODczYTIuYWlyc3BhY2UtY2RuLmNic2l2aWRlby5jb20va2VpdGhoOTdoLXRlc3QvZW4vY2FwdGlvbnNfMTc3MzkudnR0.vtt
#EXT-X-PROGRAM-DATE-TIME:2021-02-23T06:00:07.633Z
#EXTINF:6.000,
http://bakery.cbsi.video/phe(true)/aHR0cHM6Ly9kaWN0YTU0ODczYTIuYWlyc3BhY2UtY2RuLmNic2l2aWRlby5jb20va2VpdGhoOTdoLXRlc3QvZW4vY2FwdGlvbnNfMTc3NDAudnR0.vtt
#EXT-X-PROGRAM-DATE-TIME:2021-02-23T06:00:13.633Z
#EXTINF:6.000,
http://bakery.cbsi.video/phe(true)/aHR0cHM6Ly9kaWN0YTU0ODczYTIuYWlyc3BhY2UtY2RuLmNic2l2aWRlby5jb20va2VpdGhoOTdoLXRlc3QvZW4vY2FwdGlvbnNfMTc3NDEudnR0.vtt
#EXT-X-PROGRAM-DATE-TIME:2021-02-23T06:00:19.633Z
#EXTINF:6.000,
http://bakery.cbsi.video/phe(true)/aHR0cHM6Ly9kaWN0YTU0ODczYTIuYWlyc3BhY2UtY2RuLmNic2l2aWRlby5jb20va2VpdGhoOTdoLXRlc3QvZW4vY2FwdGlvbnNfMTc3NDIudnR0.vtt
#EXT-X-ENDLIST
```